### PR TITLE
feat: add usage limits to manage API costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to NPC Forge will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Usage limits to manage API costs (15 generations per month per device)
+- Progress bar showing usage and remaining generations
+- Warning notices when approaching usage limits
+- Detailed usage statistics in character display
+- Monthly auto-reset of usage counters
+
 ## [0.1.2] - 2025-04-18
 
 ### Added

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { CharacterProvider } from '@/contexts/character-context';
 import MainFormTabs from '@/components/main-form-tabs';
 import CharacterDisplay from '@/components/character-display';
+import UsageLimitsNotice from '@/components/usage-limits-notice';
 
 export default function Home() {
   return (
@@ -17,6 +18,9 @@ export default function Home() {
               AI-powered character generator for games
             </p>
           </header>
+          
+          {/* Usage Limits Notice */}
+          <UsageLimitsNotice />
           
           {/* Character Creation Form */}
           <section className="mb-12">
@@ -40,6 +44,9 @@ export default function Home() {
               >
                 GitHub Repository
               </a>
+            </p>
+            <p className="mt-3 text-xs">
+              Limited to 15 character generations per month per device.
             </p>
           </footer>
         </div>

--- a/src/components/character-display.tsx
+++ b/src/components/character-display.tsx
@@ -6,6 +6,7 @@ import TabInterface, { Tab } from '@/components/ui/tab-interface';
 import Button from '@/components/ui/button';
 import PortraitDisplay from '@/components/portrait-display';
 import JsonViewer from '@/components/json-viewer';
+import UsageLimitDisplay from '@/components/usage-limit-display';
 import { getCharacterTraitsArray } from '@/lib/utils';
 
 // Tab components for character display
@@ -148,6 +149,11 @@ export default function CharacterDisplay() {
                 />
               </div>
             )}
+            
+            {/* Usage Limit Display */}
+            <div className="mt-6">
+              <UsageLimitDisplay variant="detailed" />
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/main-form-tabs.tsx
+++ b/src/components/main-form-tabs.tsx
@@ -8,6 +8,7 @@ import CharacterTab from '@/components/tabs/character-tab';
 import QuestsTab from '@/components/tabs/quests-tab';
 import DialogueTab from '@/components/tabs/dialogue-tab';
 import ItemsTab from '@/components/tabs/items-tab';
+import UsageLimitDisplay from '@/components/usage-limit-display';
 
 export default function MainFormTabs() {
   const { 
@@ -128,8 +129,8 @@ export default function MainFormTabs() {
         </div>
       )}
       
-      {/* Generate Button */}
-      <div className="flex justify-center mt-6">
+      {/* Generate Button and Usage Display */}
+      <div className="flex flex-col items-center mt-6 space-y-3">
         <Button
           variant="primary"
           size="lg"
@@ -140,6 +141,11 @@ export default function MainFormTabs() {
         >
           Generate Character
         </Button>
+        
+        {/* Add usage limit display */}
+        <div className="w-full flex justify-center mt-3">
+          <UsageLimitDisplay variant="compact" showWhenFull={true} />
+        </div>
       </div>
     </div>
   );

--- a/src/components/usage-limit-display.tsx
+++ b/src/components/usage-limit-display.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { getUsageData, getMonthlyLimit, getRemainingGenerations } from '@/lib/usage-limits';
+
+interface UsageLimitDisplayProps {
+  variant?: 'compact' | 'detailed';
+  showWhenFull?: boolean;
+  className?: string;
+}
+
+export default function UsageLimitDisplay({ 
+  variant = 'compact', 
+  showWhenFull = true,
+  className = '' 
+}: UsageLimitDisplayProps) {
+  const [count, setCount] = useState(0);
+  const [remaining, setRemaining] = useState(0);
+  const [limit, setLimit] = useState(0);
+  const [isClient, setIsClient] = useState(false);
+  
+  // Update usage data on mount and when component is visible
+  useEffect(() => {
+    setIsClient(true);
+    
+    const updateUsage = () => {
+      const { count } = getUsageData();
+      const monthlyLimit = getMonthlyLimit();
+      const remainingGens = getRemainingGenerations();
+      
+      setCount(count);
+      setLimit(monthlyLimit);
+      setRemaining(remainingGens);
+    };
+    
+    // Initial update
+    updateUsage();
+    
+    // Update when window gains focus
+    const handleFocus = () => updateUsage();
+    window.addEventListener('focus', handleFocus);
+    
+    return () => {
+      window.removeEventListener('focus', handleFocus);
+    };
+  }, []);
+  
+  // Wait for client-side hydration
+  if (!isClient) return null;
+  
+  // Don't show anything if no usage and showWhenFull is false
+  if (count === 0 && !showWhenFull) return null;
+  
+  // Calculate percentage for progress bar
+  const usagePercentage = Math.min(100, Math.round((count / limit) * 100));
+  
+  // Determine color based on usage percentage
+  const getColorClass = () => {
+    if (usagePercentage >= 90) return 'bg-red-500';
+    if (usagePercentage >= 70) return 'bg-yellow-500';
+    return 'bg-green-500';
+  };
+  
+  if (variant === 'compact') {
+    return (
+      <div className={`text-sm flex items-center ${className}`}>
+        <div className="w-32 bg-gray-200 rounded-full h-2.5 mr-2 dark:bg-gray-700">
+          <div 
+            className={`h-2.5 rounded-full ${getColorClass()}`} 
+            style={{ width: `${usagePercentage}%` }}
+          ></div>
+        </div>
+        <span className="text-gray-600 dark:text-gray-400">
+          {remaining} left
+        </span>
+      </div>
+    );
+  }
+  
+  return (
+    <div className={`p-4 bg-white rounded-lg shadow-md dark:bg-gray-800 ${className}`}>
+      <h3 className="text-lg font-medium text-gray-800 mb-2 dark:text-white">
+        Character Generation Limit
+      </h3>
+      
+      <div className="mb-1 flex justify-between text-sm">
+        <span className="text-gray-700 dark:text-gray-300">
+          {count} of {limit} used this month
+        </span>
+        <span className={remaining === 0 ? 'text-red-500 font-medium' : 'text-gray-600 dark:text-gray-400'}>
+          {remaining} remaining
+        </span>
+      </div>
+      
+      <div className="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
+        <div 
+          className={`h-2.5 rounded-full ${getColorClass()}`} 
+          style={{ width: `${usagePercentage}%` }}
+        ></div>
+      </div>
+      
+      {remaining === 0 && (
+        <p className="mt-2 text-sm text-red-600 dark:text-red-400">
+          You've reached your monthly limit. Limits will reset at the beginning of next month.
+        </p>
+      )}
+      
+      {remaining <= 3 && remaining > 0 && (
+        <p className="mt-2 text-sm text-yellow-600 dark:text-yellow-400">
+          You're approaching your monthly limit. Use your remaining generations wisely!
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/usage-limits-notice.tsx
+++ b/src/components/usage-limits-notice.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { getRemainingGenerations } from '@/lib/usage-limits';
+
+export default function UsageLimitsNotice() {
+  const [remaining, setRemaining] = useState<number | null>(null);
+  const [isClient, setIsClient] = useState(false);
+  
+  useEffect(() => {
+    setIsClient(true);
+    const remainingGenerations = getRemainingGenerations();
+    setRemaining(remainingGenerations);
+    
+    // Update when window gains focus
+    const handleFocus = () => {
+      const remainingGenerations = getRemainingGenerations();
+      setRemaining(remainingGenerations);
+    };
+    
+    window.addEventListener('focus', handleFocus);
+    return () => window.removeEventListener('focus', handleFocus);
+  }, []);
+  
+  // Don't render during SSR or if we have plenty of generations left
+  if (!isClient || remaining === null || remaining > 3) {
+    return null;
+  }
+  
+  if (remaining === 0) {
+    return (
+      <div className="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mb-6 dark:bg-red-900/30 dark:border-red-700 dark:text-red-300">
+        <div className="flex items-start">
+          <div className="flex-shrink-0">
+            <svg className="h-5 w-5 text-red-500" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
+            </svg>
+          </div>
+          <div className="ml-3">
+            <h3 className="text-sm font-medium">Generation Limit Reached</h3>
+            <div className="mt-2 text-sm">
+              <p>
+                You've reached your monthly character generation limit. Limits will reset at the beginning of next month.
+              </p>
+              <p className="mt-2">
+                Save your existing characters as JSON files and consider keeping your own character library.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+  
+  return (
+    <div className="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4 mb-6 dark:bg-yellow-900/30 dark:border-yellow-700 dark:text-yellow-300">
+      <div className="flex items-start">
+        <div className="flex-shrink-0">
+          <svg className="h-5 w-5 text-yellow-500" viewBox="0 0 20 20" fill="currentColor">
+            <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+          </svg>
+        </div>
+        <div className="ml-3">
+          <h3 className="text-sm font-medium">Generation Limit Warning</h3>
+          <div className="mt-2 text-sm">
+            <p>
+              You have only <strong>{remaining}</strong> character generation{remaining === 1 ? '' : 's'} remaining this month.
+            </p>
+            <p className="mt-2">
+              Remember to save your characters as JSON files to view them again later.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/usage-limits.ts
+++ b/src/lib/usage-limits.ts
@@ -1,0 +1,118 @@
+/**
+ * Utility for tracking and managing character generation usage limits
+ * Uses localStorage to track generations on a per-month basis
+ */
+
+// Constants
+const STORAGE_KEY = 'npc-forge-usage';
+const DEFAULT_MONTHLY_LIMIT = 15; // Default limit of 15 generations per month
+
+// Define usage data structure
+interface UsageData {
+  count: number;         // Number of generations this month
+  monthKey: string;      // Current month identifier (YYYY-MM format)
+  lastUpdated: string;   // ISO date string of last update
+}
+
+/**
+ * Get the current month key in YYYY-MM format
+ */
+function getCurrentMonthKey(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+}
+
+/**
+ * Get the current usage data from localStorage
+ */
+export function getUsageData(): UsageData {
+  // Default data for new users
+  const defaultData: UsageData = {
+    count: 0,
+    monthKey: getCurrentMonthKey(),
+    lastUpdated: new Date().toISOString()
+  };
+  
+  // Check if localStorage is available (will not be in SSR)
+  if (typeof window === 'undefined' || typeof localStorage === 'undefined') {
+    return defaultData;
+  }
+  
+  try {
+    // Try to get and parse stored data
+    const storedData = localStorage.getItem(STORAGE_KEY);
+    if (!storedData) return defaultData;
+    
+    const parsedData: UsageData = JSON.parse(storedData);
+    const currentMonthKey = getCurrentMonthKey();
+    
+    // Reset count if it's a new month
+    if (parsedData.monthKey !== currentMonthKey) {
+      const resetData: UsageData = {
+        count: 0,
+        monthKey: currentMonthKey,
+        lastUpdated: new Date().toISOString()
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(resetData));
+      return resetData;
+    }
+    
+    return parsedData;
+  } catch (error) {
+    console.error('Error reading usage data:', error);
+    return defaultData;
+  }
+}
+
+/**
+ * Increment the usage count when a character is generated
+ */
+export function incrementUsage(): UsageData {
+  const currentData = getUsageData();
+  const updatedData: UsageData = {
+    ...currentData,
+    count: currentData.count + 1,
+    lastUpdated: new Date().toISOString()
+  };
+  
+  // Save to localStorage if available
+  if (typeof window !== 'undefined' && typeof localStorage !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(updatedData));
+  }
+  
+  return updatedData;
+}
+
+/**
+ * Check if the user has reached their monthly limit
+ */
+export function hasReachedLimit(customLimit?: number): boolean {
+  const { count } = getUsageData();
+  const limit = customLimit || DEFAULT_MONTHLY_LIMIT;
+  return count >= limit;
+}
+
+/**
+ * Get the number of remaining generations for the current month
+ */
+export function getRemainingGenerations(customLimit?: number): number {
+  const { count } = getUsageData();
+  const limit = customLimit || DEFAULT_MONTHLY_LIMIT;
+  return Math.max(0, limit - count);
+}
+
+/**
+ * Get the current monthly limit
+ */
+export function getMonthlyLimit(): number {
+  return DEFAULT_MONTHLY_LIMIT;
+}
+
+/**
+ * Clear usage data (for testing purposes)
+ */
+export function clearUsageData(): void {
+  if (typeof window !== 'undefined' && typeof localStorage !== 'undefined') {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+}


### PR DESCRIPTION
### Added
- Usage limits to manage API costs (15 generations per month per device)
- Progress bar showing usage and remaining generations
- Warning notices when approaching usage limits
- Detailed usage statistics in character display
- Monthly auto-reset of usage counters