### PR TITLE
fix: immediately update usage count after generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced error handling with specific messages for common API issues
 - Strengthened JSON response validation with required field checking
 
+### Fixed
+- Immediate update of usage count after character generation
+
 ## [0.1.2] - 2025-04-18
 
 ### Added

--- a/src/components/character-display.tsx
+++ b/src/components/character-display.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useCharacter } from '@/contexts/character-context';
 import TabInterface, { Tab } from '@/components/ui/tab-interface';
 import Button from '@/components/ui/button';
@@ -24,13 +24,21 @@ export default function CharacterDisplay() {
   
   const [activeTab, setActiveTab] = useState('profile');
   const [showJson, setShowJson] = useState(false);
+  const [refreshCounter, setRefreshCounter] = useState(0);
   
   // Reset to profile tab when character changes
   useEffect(() => {
     if (character) {
       setActiveTab('profile');
+      // Force refresh of usage counts whenever a character is generated
+      setRefreshCounter(prev => prev + 1);
     }
   }, [character]);
+  
+  // Callback for refreshing the count
+  const refreshUsageCount = useCallback(() => {
+    setRefreshCounter(prev => prev + 1);
+  }, []);
   
   if (!character) {
     return null;
@@ -152,7 +160,11 @@ export default function CharacterDisplay() {
             
             {/* Usage Limit Display */}
             <div className="mt-6">
-              <UsageLimitDisplay variant="detailed" />
+              <UsageLimitDisplay 
+                variant="detailed" 
+                refreshKey={refreshCounter} 
+                onRefresh={refreshUsageCount}
+              />
             </div>
           </div>
         </div>

--- a/src/components/usage-limit-display.tsx
+++ b/src/components/usage-limit-display.tsx
@@ -7,19 +7,23 @@ interface UsageLimitDisplayProps {
   variant?: 'compact' | 'detailed';
   showWhenFull?: boolean;
   className?: string;
+  refreshKey?: number; // Add a key to force refresh
+  onRefresh?: () => void; // Optional callback after refresh
 }
 
 export default function UsageLimitDisplay({ 
   variant = 'compact', 
   showWhenFull = true,
-  className = '' 
+  className = '',
+  refreshKey = 0,
+  onRefresh
 }: UsageLimitDisplayProps) {
   const [count, setCount] = useState(0);
   const [remaining, setRemaining] = useState(0);
   const [limit, setLimit] = useState(0);
   const [isClient, setIsClient] = useState(false);
   
-  // Update usage data on mount and when component is visible
+  // Update usage data on mount, refreshKey change, and when component is visible
   useEffect(() => {
     setIsClient(true);
     
@@ -31,6 +35,11 @@ export default function UsageLimitDisplay({
       setCount(count);
       setLimit(monthlyLimit);
       setRemaining(remainingGens);
+      
+      // Call refresh callback if provided
+      if (onRefresh) {
+        onRefresh();
+      }
     };
     
     // Initial update
@@ -43,7 +52,7 @@ export default function UsageLimitDisplay({
     return () => {
       window.removeEventListener('focus', handleFocus);
     };
-  }, []);
+  }, [refreshKey, onRefresh]);
   
   // Wait for client-side hydration
   if (!isClient) return null;


### PR DESCRIPTION
### Changes:
- Added a refresh counter state to force updates of the usage display
- Updated the character-display component to increment the counter on character generation
- Added refreshKey prop to the UsageLimitDisplay component
- Implemented an optional callback for post-refresh actions
- Enhanced the useEffect dependency array to trigger on refreshKey changes