### PR TITLE
update: change 'None' to 'Not specified' in all dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved OpenAI prompt design to prevent prompt injection
 - Enhanced error handling with specific messages for common API issues
 - Strengthened JSON response validation with required field checking
+- Updated all dropdown menus to use "Not specified" instead of "None"
 
 ### Fixed
 - Immediate update of usage count after character generation

--- a/src/components/tabs/portrait-options.tsx
+++ b/src/components/tabs/portrait-options.tsx
@@ -4,9 +4,9 @@ import { useCharacter } from '@/contexts/character-context';
 import ExpandableSection from '@/components/ui/expandable-section';
 import Select from '@/components/ui/select';
 
-// Options for portrait customization with "None" as first option
+// Options for portrait customization with "Not specified" as first option
 const artStyleOptions = [
-  { value: '', label: 'None' },
+  { value: '', label: 'Not specified' },
   { value: 'realistic', label: 'Realistic' },
   { value: 'fantasy', label: 'Fantasy Art' },
   { value: 'anime', label: 'Anime/Manga' },
@@ -18,7 +18,7 @@ const artStyleOptions = [
 ];
 
 const moodOptions = [
-  { value: '', label: 'None' },
+  { value: '', label: 'Not specified' },
   { value: 'neutral', label: 'Neutral' },
   { value: 'happy', label: 'Happy/Smiling' },
   { value: 'serious', label: 'Serious' },
@@ -30,7 +30,7 @@ const moodOptions = [
 ];
 
 const framingOptions = [
-  { value: '', label: 'None' },
+  { value: '', label: 'Not specified' },
   { value: 'portrait', label: 'Portrait (Head/Shoulders)' },
   { value: 'bust', label: 'Bust (Upper Body)' },
   { value: 'full-body', label: 'Full Body' },
@@ -38,7 +38,7 @@ const framingOptions = [
 ];
 
 const backgroundOptions = [
-  { value: '', label: 'None' },
+  { value: '', label: 'Not specified' },
   { value: 'plain', label: 'Plain/Solid Color' },
   { value: 'gradient', label: 'Gradient' },
   { value: 'themed', label: 'Themed (Based on Character)' },


### PR DESCRIPTION
### Changes:
- Updated all dropdown menus to use "Not specified" instead of "None"
- Added "Not specified" as a consistent option for the occupation selector
- Improved the occupation list with more relevant options organized by genre
- Removed niche occupations that were too specific
- Added more general occupations applicable across genres