### PR TITLE
fix: preserve sub-genre selection when switching tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mobile responsiveness and layout issues
 - Improved tab interface behavior and styling
 - Fixed infinite update loop in usage limit display
+- Sub-genre persistence fix when changing tabs
 
 ## [0.1.3] - 2025-04-19
 

--- a/src/components/tabs/character-tab.tsx
+++ b/src/components/tabs/character-tab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useCharacter } from '@/contexts/character-context';
 import TemplateSelector from '@/components/template-selector';
 import Select from '@/components/ui/select';
@@ -346,6 +346,7 @@ export default function CharacterTab() {
         <TemplateSelector
           templates={GENRE_TEMPLATES}
           selectedId={formData.genre}
+          selectedSubGenreId={formData.sub_genre} // Pass the selected sub-genre ID
           onChange={handleGenreChange}
         />
       </div>

--- a/src/components/template-selector.tsx
+++ b/src/components/template-selector.tsx
@@ -2,12 +2,13 @@
 
 import { useState, useEffect } from 'react';
 import { TemplateOption, SubGenreOption } from '@/lib/types';
-import { getSubGenres } from '@/lib/templates';
+import { getSubGenres, getAllSubGenres } from '@/lib/templates';
 import GenreIcon from '@/components/ui/genre-icon';
 
 interface TemplateSelectorProps {
   templates: TemplateOption[];
   selectedId?: string;
+  selectedSubGenreId?: string; // Add new prop for selected sub-genre
   onChange: (template: TemplateOption | undefined, subGenre?: SubGenreOption) => void;
   className?: string;
 }
@@ -15,12 +16,13 @@ interface TemplateSelectorProps {
 export default function TemplateSelector({
   templates,
   selectedId,
+  selectedSubGenreId,
   onChange,
   className = ''
 }: TemplateSelectorProps) {
   const [hoveredId, setHoveredId] = useState<string | null>(null);
   const [selectedGenre, setSelectedGenre] = useState<string | undefined>(selectedId);
-  const [selectedSubGenre, setSelectedSubGenre] = useState<string | undefined>(undefined);
+  const [selectedSubGenre, setSelectedSubGenre] = useState<string | undefined>(selectedSubGenreId);
   const [availableSubGenres, setAvailableSubGenres] = useState<SubGenreOption[]>([]);
   
   // Update sub-genres when a main genre is selected
@@ -37,8 +39,20 @@ export default function TemplateSelector({
   // Reset selections when selectedId changes externally
   useEffect(() => {
     setSelectedGenre(selectedId);
-    setSelectedSubGenre(undefined);
-  }, [selectedId]);
+    
+    // Only set selectedSubGenre if selectedId matches current selectedGenre
+    // This prevents unsetting the sub-genre when genre stays the same
+    if (selectedId !== selectedGenre) {
+      setSelectedSubGenre(selectedSubGenreId);
+    }
+  }, [selectedId, selectedSubGenreId, selectedGenre]);
+  
+  // Initialize selectedSubGenre from selectedSubGenreId
+  useEffect(() => {
+    if (selectedSubGenreId && selectedId) {
+      setSelectedSubGenre(selectedSubGenreId);
+    }
+  }, []);
   
   const handleSelectGenre = (template: TemplateOption) => {
     // If already selected, deselect it


### PR DESCRIPTION
### Changed:
- Sub-genre selection was not persisting visually when switching between tabs in the character creation form so the reset logic in TemplateSelector was modified to preserve sub-genre selection on component re-render.