### PR TITLE
feat: update usage limit display to show most constrained model selec…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Usage limit display and notification components now compare the user's selected text and image models
+- Displays whichever selected model has fewer remaining generations (e.g., "7 Portrait Premium generations remaining")
 
 ## [0.2.1] - 2025-04-29
 

--- a/src/components/usage-limits-notice.tsx
+++ b/src/components/usage-limits-notice.tsx
@@ -2,32 +2,116 @@
 
 import { useState, useEffect } from 'react';
 import { getRemainingGenerations } from '@/lib/usage-limits';
+import { useCharacter } from '@/contexts/character-context';
+import { getModelConfig } from '@/lib/models';
+import { getImageModelConfig } from '@/lib/image-models';
 
 export default function UsageLimitsNotice() {
-  const [remaining, setRemaining] = useState<number | string | null>(null);
+  const { formData } = useCharacter();
+  const [mostLimitedInfo, setMostLimitedInfo] = useState<{
+    modelType: 'text' | 'image';
+    modelId: string;
+    remaining: number | string;
+    label: string;
+    emoji: string;
+  } | null>(null);
   const [isClient, setIsClient] = useState(false);
   
   useEffect(() => {
     setIsClient(true);
-    const remainingGenerations = getRemainingGenerations();
-    setRemaining(remainingGenerations);
+    
+    const updateUsage = () => {
+      // Get the selected models
+      const textModel = formData.model;
+      const imageModel = formData.portrait_options?.image_model;
+      
+      if (!textModel && !imageModel) return;
+      
+      // Get text model info
+      let textRemaining: number | string = Infinity;
+      let textModelInfo = null;
+      
+      if (textModel) {
+        const textModelConfig = getModelConfig(textModel);
+        textRemaining = getRemainingGenerations(textModel);
+        
+        textModelInfo = {
+          modelType: 'text' as const,
+          modelId: textModel,
+          remaining: textRemaining,
+          label: textModelConfig.label,
+          emoji: textModelConfig.emoji
+        };
+      }
+      
+      // Get image model info
+      let imageRemaining: number | string = Infinity;
+      let imageModelInfo = null;
+      
+      if (imageModel) {
+        const imageModelConfig = getImageModelConfig(imageModel);
+        imageRemaining = getRemainingGenerations(imageModel);
+        
+        imageModelInfo = {
+          modelType: 'image' as const,
+          modelId: imageModel,
+          remaining: imageRemaining,
+          label: imageModelConfig.label,
+          emoji: imageModelConfig.emoji
+        };
+      }
+      
+      // Compare to find the most limited option
+      // If one is "Unlimited", use the other
+      // If both are numbers, use the smaller one
+      // If both are "Unlimited", use text model
+      
+      if (textRemaining === "Unlimited" && imageRemaining === "Unlimited") {
+        setMostLimitedInfo(null); // Both are unlimited, don't show any notice
+      }
+      else if (textRemaining === "Unlimited") {
+        setMostLimitedInfo(imageModelInfo);
+      }
+      else if (imageRemaining === "Unlimited") {
+        setMostLimitedInfo(textModelInfo);
+      }
+      else if (typeof textRemaining === 'number' && typeof imageRemaining === 'number') {
+        // Both are numbers, choose the smaller one
+        setMostLimitedInfo(textRemaining <= imageRemaining ? textModelInfo : imageModelInfo);
+      }
+      else {
+        // Fallback in case of unexpected types
+        setMostLimitedInfo(textModelInfo || imageModelInfo);
+      }
+    };
+    
+    // Initial update
+    updateUsage();
     
     // Update when window gains focus
     const handleFocus = () => {
-      const remainingGenerations = getRemainingGenerations();
-      setRemaining(remainingGenerations);
+      updateUsage();
     };
     
     window.addEventListener('focus', handleFocus);
     return () => window.removeEventListener('focus', handleFocus);
-  }, []);
+  }, [formData.model, formData.portrait_options?.image_model]);
   
-  // Don't render during SSR or if we have plenty of generations left or unlimited
-  if (!isClient || remaining === null || remaining === "Unlimited" || (typeof remaining === 'number' && remaining > 3)) {
+  // Don't render during SSR or if we don't have info yet or if we have plenty of resources
+  if (!isClient || !mostLimitedInfo) {
     return null;
   }
   
-  if (remaining === 0) {
+  // Don't show if more than 3 remaining
+  if (mostLimitedInfo.remaining === "Unlimited" || 
+      (typeof mostLimitedInfo.remaining === 'number' && mostLimitedInfo.remaining > 3)) {
+    return null;
+  }
+  
+  // Create a user-friendly label for the model
+  const limitTypeLabel = mostLimitedInfo.modelType === 'text' ? 'character' : 'portrait';
+  
+  if (mostLimitedInfo.remaining === 0) {
     return (
       <div className="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mb-6 dark:bg-red-900/30 dark:border-red-700 dark:text-red-300">
         <div className="flex items-start">
@@ -37,13 +121,13 @@ export default function UsageLimitsNotice() {
             </svg>
           </div>
           <div className="ml-3">
-            <h3 className="text-sm font-medium">Generation Limit Reached</h3>
+            <h3 className="text-sm font-medium">{mostLimitedInfo.emoji} Generation Limit Reached</h3>
             <div className="mt-2 text-sm">
               <p>
-                You've reached your monthly character generation limit. Limits will reset at the beginning of next month.
+                You've reached your monthly limit for {mostLimitedInfo.label} {limitTypeLabel} generations.
               </p>
               <p className="mt-2">
-                Save your existing characters as JSON files and consider keeping your own character library.
+                Try selecting a different model tier or wait until next month.
               </p>
             </div>
           </div>
@@ -61,13 +145,13 @@ export default function UsageLimitsNotice() {
           </svg>
         </div>
         <div className="ml-3">
-          <h3 className="text-sm font-medium">Generation Limit Warning</h3>
+          <h3 className="text-sm font-medium">{mostLimitedInfo.emoji} Generation Limit Warning</h3>
           <div className="mt-2 text-sm">
             <p>
-              You have only <strong>{remaining}</strong> character generation{remaining === 1 ? '' : 's'} remaining this month.
+              You have only <strong>{mostLimitedInfo.remaining}</strong> {mostLimitedInfo.label} {limitTypeLabel} generation{mostLimitedInfo.remaining === 1 ? '' : 's'} remaining.
             </p>
             <p className="mt-2">
-              Remember to save your characters as JSON files to view them again later.
+              Consider selecting a different model tier or remember to save your characters as JSON files.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Improves usage limit visibility by displaying the most constrained selected model (character or portrait) in both the usage indicator and notification UI. Helps users better understand which resource is most limiting at a glance.

## Changes

### Added
- Detection logic to compare selected text and image models' remaining generations
- Display of the model with the fewest remaining generations (e.g., "7 Portrait Premium generations remaining")

### Changed
- `usage-limit-display.tsx` and `usage-limits-notice.tsx`:
  - Rewritten to check both selected model types and display the lower of the two
  - Progress bar and remaining text now dynamically reflect the more constrained model
- Text phrasing refined for natural language:
  - Uses `"Unlimited Portraits"` for cheap tier
  - Uses `"7 Portrait Premium generations remaining"` for limited tiers
- Context usage clarified to pull current model selections from `CharacterFormData`
