### PR TITLE
fix: optimize mobile layout on character generator screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `EditPageFooter` component to support consistent navigation on the Edit screen.
+
 ### Changed
 - Improved navigation layout:
   - Added header to the Edit and Library pages for a consistent experience across views.
-  - On mobile, the header now auto-closes when the sidebar opens.
+  - On mobile:
+    - The header now auto-closes when the sidebar opens.
+    - The stepper is now hidden when the sidebar is open to reduce visual clutter.
+    - Adjusted spacing to ensure the sidebar toggle does not overlap the header title.
 - Enhanced user flow:
   - Added a "Back to Library" button after character generation for quicker navigation.
 - Refactored Edit Page layout:
   - Integrated a sticky footer for persistent navigation actions on the Edit page.
   - Simplified and polished existing edit-page components for clarity and reusability (e.g., `HeaderSection`, `PortraitSection`, `CharacterTraitsSection`, etc.).
-
-### Added
-- `EditPageFooter` component to support consistent navigation on the Edit screen.
 
 ## [0.13.2] - 2025-05-22
 

--- a/src/components/character-wizard.tsx
+++ b/src/components/character-wizard.tsx
@@ -21,6 +21,7 @@ export default function CharacterWizard() {
   const [currentStep, setCurrentStep] = useState(0);
   const [forceStep, setForceStep] = useState<number | null>(null);
   const manualNavRef = useRef<boolean>(false);
+  const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
   
   const { 
     formData, 
@@ -31,6 +32,22 @@ export default function CharacterWizard() {
     error, 
     generateRandomCharacter 
   } = useCharacter();
+
+  // Listen for sidebar state changes
+  useEffect(() => {
+    const handleSidebarChange = (e: CustomEvent) => {
+      // If mobile sidebar state is provided, update our state
+      if (e.detail.mobileOpen !== undefined) {
+        setIsMobileSidebarOpen(e.detail.mobileOpen);
+      }
+    };
+    
+    window.addEventListener('sidebarStateChange' as any, handleSidebarChange as EventListener);
+    
+    return () => {
+      window.removeEventListener('sidebarStateChange' as any, handleSidebarChange as EventListener);
+    };
+  }, []);
 
   // Handle step navigation - allow navigation to any step if description exists
   const goToStep = (stepIndex: number) => {
@@ -203,37 +220,39 @@ export default function CharacterWizard() {
 
   return (
     <div className="max-w-full">
-      {/* Sticky Progress Header */}
-      <div className="sticky top-0 z-40 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 mb-8">
-        <div className="max-w-full px-4 py-4">
-          <div className="flex justify-center">
-            {STEPS.map((step, index) => (
-              <div key={step.id} className="flex items-center">
-                <button
-                  onClick={() => goToStep(index)}
-                  className={`
-                    w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium transition-colors
-                    ${index <= currentStep 
-                      ? 'bg-indigo-600 text-white cursor-pointer hover:bg-indigo-700' 
-                      : isStepAccessible(index)
-                        ? 'bg-gray-300 text-gray-700 cursor-pointer hover:bg-gray-400 dark:bg-gray-600 dark:text-gray-100'
-                        : 'bg-gray-200 text-gray-500 cursor-not-allowed dark:bg-gray-700 dark:text-gray-400'}
-                  `}
-                  disabled={!isStepAccessible(index)}
-                >
-                  {index + 1}
-                </button>
-                <span className={`ml-2 text-sm ${index <= currentStep ? 'text-gray-900 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400'}`}>
-                  {step.label}
-                </span>
-                {index < STEPS.length - 1 && (
-                  <ChevronRight className="mx-3 h-4 w-4 text-gray-400" />
-                )}
-              </div>
-            ))}
+      {/* Sticky Progress Header - Hide when mobile sidebar is open */}
+      {!isMobileSidebarOpen && (
+        <div className="sticky top-0 z-40 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 mb-8">
+          <div className="max-w-full px-4 py-4">
+            <div className="flex justify-center">
+              {STEPS.map((step, index) => (
+                <div key={step.id} className="flex items-center">
+                  <button
+                    onClick={() => goToStep(index)}
+                    className={`
+                      w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium transition-colors
+                      ${index <= currentStep 
+                        ? 'bg-indigo-600 text-white cursor-pointer hover:bg-indigo-700' 
+                        : isStepAccessible(index)
+                          ? 'bg-gray-300 text-gray-700 cursor-pointer hover:bg-gray-400 dark:bg-gray-600 dark:text-gray-100'
+                          : 'bg-gray-200 text-gray-500 cursor-not-allowed dark:bg-gray-700 dark:text-gray-400'}
+                    `}
+                    disabled={!isStepAccessible(index)}
+                  >
+                    {index + 1}
+                  </button>
+                  <span className={`ml-2 text-sm ${index <= currentStep ? 'text-gray-900 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400'}`}>
+                    {step.label}
+                  </span>
+                  {index < STEPS.length - 1 && (
+                    <ChevronRight className="mx-3 h-4 w-4 text-gray-400" />
+                  )}
+                </div>
+              ))}
+            </div>
           </div>
         </div>
-      </div>
+      )}
 
       {/* Step Content */}
       <div className="px-4 mb-16">

--- a/src/components/client-layout.tsx
+++ b/src/components/client-layout.tsx
@@ -43,7 +43,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
         >
           <div className="flex justify-between items-center h-12">
             {/* Only show app title on medium+ screens or when sidebar is collapsed */}
-            <div className={`${isExpanded ? 'hidden lg:flex' : 'flex'} items-center`}>
+            <div className={`${isExpanded ? 'hidden lg:flex' : 'flex'} items-center pl-12 sm:pl-0`}>
               <Link href="/" className="text-xl font-bold flex items-center">
                 <Sparkles className="h-5 w-5 mr-2 text-indigo-600 dark:text-indigo-400" />
                 NPC Forge


### PR DESCRIPTION
## Summary

This PR resolves remaining mobile layout issues on the character generation screen.

## Changes

### Changed
- Hid the stepper ("1 Concept → 4 Generate") on mobile when the sidebar is open to reduce visual clutter.
- Adjusted header spacing to prevent the sidebar toggle button from overlapping the page title.

