### PR TITLE
Implement AI-powered portrait editing and trait tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- AI-powered portrait editing via text prompts using OpenAI’s `/v1/images/edits` endpoint (supports `gpt-image-1`)
+- "Add Generated Trait" button in Additional Traits section to generate a new short trait via AI
+- Individual regenerate buttons for each trait in the Additional Traits section
+
+### Changed
+- Trait filtering now excludes long or sentence-like traits entirely (instead of truncating them)
+- Trait formatting standardized to Title Case throughout the UI
+- Additional Traits display logic now matches exactly between the character modal and edit page
+- Navigation back to the Library after saving changes is now immediate with no artificial delay
+
+### Fixed
+- Traits missing from the edit page but visible in the modal due to inconsistent filtering logic
+
 ## [0.20.1] - 2025-06-10
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "openai": "^4.93.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "sharp": "^0.34.2",
         "tailwind-merge": "^3.2.0"
       },
       "devDependencies": {
@@ -73,9 +74,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.1.tgz",
-      "integrity": "sha512-LMshMVP0ZhACNjQNYXiU1iZJ6QCcv0lUdPDPugqGvCGXt5xtRVBPdtA0qU12pEXZzpWAhWlZYptfdAFq10DOVQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
+      "integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -349,9 +350,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.1.tgz",
-      "integrity": "sha512-pn44xgBtgpEbZsu+lWf2KNb6OAf70X68k+yk69Ic2Xz11zHR/w24/U49XT7AeRwJ0Px+mhALhU5LPci1Aymk7A==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.2.tgz",
+      "integrity": "sha512-OfXHZPppddivUJnqyKoi5YVeHRkkNE2zUFT2gbpKxp/JZCFYEYubnMg+gOp6lWfasPrTS+KPosKqdI+ELYVDtg==",
       "cpu": [
         "arm64"
       ],
@@ -371,9 +372,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.1.tgz",
-      "integrity": "sha512-VfuYgG2r8BpYiOUN+BfYeFo69nP/MIwAtSJ7/Zpxc5QF3KS22z8Pvg3FkrSFJBPNQ7mmcUcYQFBmEQp7eu1F8Q==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.2.tgz",
+      "integrity": "sha512-dYvWqmjU9VxqXmjEtjmvHnGqF8GrVjM2Epj9rJ6BUIXvk8slvNDJbhGFvIoXzkDhrJC2jUxNLz/GUjjvSzfw+g==",
       "cpu": [
         "x64"
       ],
@@ -537,9 +538,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.1.tgz",
-      "integrity": "sha512-anKiszvACti2sGy9CirTlNyk7BjjZPiML1jt2ZkTdcvpLU1YH6CXwRAZCA2UmRXnhiIftXQ7+Oh62Ji25W72jA==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.2.tgz",
+      "integrity": "sha512-0DZzkvuEOqQUP9mo2kjjKNok5AmnOr1jB2XYjkaoNRwpAYMDzRmAqUIa1nRi58S2WswqSfPOWLNOr0FDT3H5RQ==",
       "cpu": [
         "arm"
       ],
@@ -559,9 +560,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.1.tgz",
-      "integrity": "sha512-kX2c+vbvaXC6vly1RDf/IWNXxrlxLNpBVWkdpRq5Ka7OOKj6nr66etKy2IENf6FtOgklkg9ZdGpEu9kwdlcwOQ==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.2.tgz",
+      "integrity": "sha512-D8n8wgWmPDakc83LORcfJepdOSN6MvWNzzz2ux0MnIbOqdieRZwVYY32zxVx+IFUT8er5KPcyU3XXsn+GzG/0Q==",
       "cpu": [
         "arm64"
       ],
@@ -581,9 +582,9 @@
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.1.tgz",
-      "integrity": "sha512-7s0KX2tI9mZI2buRipKIw2X1ufdTeaRgwmRabt5bi9chYfhur+/C1OXg3TKg/eag1W+6CCWLVmSauV1owmRPxA==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.2.tgz",
+      "integrity": "sha512-EGZ1xwhBI7dNISwxjChqBGELCWMGDvmxZXKjQRuqMrakhO8QoMgqCrdjnAqJq/CScxfRn+Bb7suXBElKQpPDiw==",
       "cpu": [
         "s390x"
       ],
@@ -603,9 +604,9 @@
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.1.tgz",
-      "integrity": "sha512-wExv7SH9nmoBW3Wr2gvQopX1k8q2g5V5Iag8Zk6AVENsjwd+3adjwxtp3Dcu2QhOXr8W9NusBU6XcQUohBZ5MA==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.2.tgz",
+      "integrity": "sha512-sD7J+h5nFLMMmOXYH4DD9UtSNBD05tWSSdWAcEyzqW8Cn5UxXvsHAxmxSesYUsTOBmUnjtxghKDl15EvfqLFbQ==",
       "cpu": [
         "x64"
       ],
@@ -625,9 +626,9 @@
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.1.tgz",
-      "integrity": "sha512-DfvyxzHxw4WGdPiTF0SOHnm11Xv4aQexvqhRDAoD00MzHekAj9a/jADXeXYCDFH/DzYruwHbXU7uz+H+nWmSOQ==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.2.tgz",
+      "integrity": "sha512-NEE2vQ6wcxYav1/A22OOxoSOGiKnNmDzCYFOZ949xFmrWZOVII1Bp3NqVVpvj+3UeHMFyN5eP/V5hzViQ5CZNA==",
       "cpu": [
         "arm64"
       ],
@@ -647,9 +648,9 @@
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.1.tgz",
-      "integrity": "sha512-pax/kTR407vNb9qaSIiWVnQplPcGU8LRIJpDT5o8PdAx5aAA7AS3X9PS8Isw1/WfqgQorPotjrZL3Pqh6C5EBg==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.2.tgz",
+      "integrity": "sha512-DOYMrDm5E6/8bm/yQLCWyuDJwUnlevR8xtF8bs+gjZ7cyUNYXiSf/E8Kp0Ss5xasIaXSHzb888V1BE4i1hFhAA==",
       "cpu": [
         "x64"
       ],
@@ -669,16 +670,16 @@
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.1.tgz",
-      "integrity": "sha512-YDybQnYrLQfEpzGOQe7OKcyLUCML4YOXl428gOOzBgN6Gw0rv8dpsJ7PqTHxBnXnwXr8S1mYFSLSa727tpz0xg==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.2.tgz",
+      "integrity": "sha512-/VI4mdlJ9zkaq53MbIG6rZY+QRN3MLbR6usYlgITEzi4Rpx5S6LFKsycOQjkOGmqTNmkIdLjEvooFKwww6OpdQ==",
       "cpu": [
         "wasm32"
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.4.0"
+        "@emnapi/runtime": "^1.4.3"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -687,10 +688,29 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.2.tgz",
+      "integrity": "sha512-cfP/r9FdS63VA5k0xiqaNaEoGxBg9k7uE+RQGzuK9fHt7jib4zAVVseR9LsE4gJcNWgT6APKMNnCcnyOtmSEUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.1.tgz",
-      "integrity": "sha512-WKf/NAZITnonBf3U1LfdjoMgNO5JYRSlhovhRhMxXVdvWYveM4kM3L8m35onYIdh75cOMCo1BexgVQcCDzyoWw==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.2.tgz",
+      "integrity": "sha512-QLjGGvAbj0X/FXl8n1WbtQ6iVBpWU7JO94u/P2M4a8CFYsvQi4GW2mRy/JqkRx0qpBzaOdKJKw8uc930EX2AHw==",
       "cpu": [
         "ia32"
       ],
@@ -707,9 +727,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.1.tgz",
-      "integrity": "sha512-hw1iIAHpNE8q3uMIRCgGOeDoz9KtFNarFLQclLxr/LK1VBkj8nby18RjFvr6aP7USRYAjTZW6yisnBWMX571Tw==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.2.tgz",
+      "integrity": "sha512-aUdT6zEYtDKCaxkofmmJDJYGCf0+pJg3eU9/oBuqvEeoB9dKI6ZLc/1iLJCTuJQDO4ptntAlkUmHgGjyuobZbw==",
       "cpu": [
         "x64"
       ],
@@ -2877,7 +2897,6 @@
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
       "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -2890,7 +2909,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2903,7 +2921,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/color-string": {
@@ -2911,7 +2928,6 @@
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
       "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -3097,10 +3113,9 @@
       }
     },
     "node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
-      "devOptional": true,
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -4323,8 +4338,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -6038,10 +6052,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "devOptional": true,
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6100,16 +6113,15 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.1.tgz",
-      "integrity": "sha512-1j0w61+eVxu7DawFJtnfYcvSv6qPFvfTaqzTQ2BLknVhHTwGS8sc63ZBF4rzkWMBVKybo4S5OBtDdZahh2A1xg==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.2.tgz",
+      "integrity": "sha512-lszvBmB9QURERtyKT2bNmsgxXK0ShJrL/fvqlonCo7e6xBF8nT8xU6pW+PMIbLsz0RxQk3rgH9kd8UmvOzlMJg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "color": "^4.2.3",
-        "detect-libc": "^2.0.3",
-        "semver": "^7.7.1"
+        "detect-libc": "^2.0.4",
+        "semver": "^7.7.2"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -6118,8 +6130,8 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.1",
-        "@img/sharp-darwin-x64": "0.34.1",
+        "@img/sharp-darwin-arm64": "0.34.2",
+        "@img/sharp-darwin-x64": "0.34.2",
         "@img/sharp-libvips-darwin-arm64": "1.1.0",
         "@img/sharp-libvips-darwin-x64": "1.1.0",
         "@img/sharp-libvips-linux-arm": "1.1.0",
@@ -6129,15 +6141,16 @@
         "@img/sharp-libvips-linux-x64": "1.1.0",
         "@img/sharp-libvips-linuxmusl-arm64": "1.1.0",
         "@img/sharp-libvips-linuxmusl-x64": "1.1.0",
-        "@img/sharp-linux-arm": "0.34.1",
-        "@img/sharp-linux-arm64": "0.34.1",
-        "@img/sharp-linux-s390x": "0.34.1",
-        "@img/sharp-linux-x64": "0.34.1",
-        "@img/sharp-linuxmusl-arm64": "0.34.1",
-        "@img/sharp-linuxmusl-x64": "0.34.1",
-        "@img/sharp-wasm32": "0.34.1",
-        "@img/sharp-win32-ia32": "0.34.1",
-        "@img/sharp-win32-x64": "0.34.1"
+        "@img/sharp-linux-arm": "0.34.2",
+        "@img/sharp-linux-arm64": "0.34.2",
+        "@img/sharp-linux-s390x": "0.34.2",
+        "@img/sharp-linux-x64": "0.34.2",
+        "@img/sharp-linuxmusl-arm64": "0.34.2",
+        "@img/sharp-linuxmusl-x64": "0.34.2",
+        "@img/sharp-wasm32": "0.34.2",
+        "@img/sharp-win32-arm64": "0.34.2",
+        "@img/sharp-win32-ia32": "0.34.2",
+        "@img/sharp-win32-x64": "0.34.2"
       }
     },
     "node_modules/shebang-command": {
@@ -6244,7 +6257,6 @@
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "openai": "^4.93.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "sharp": "^0.34.2",
     "tailwind-merge": "^3.2.0"
   },
   "devDependencies": {

--- a/src/app/api/edit-portrait/route.ts
+++ b/src/app/api/edit-portrait/route.ts
@@ -1,0 +1,389 @@
+// src/app/api/edit-portrait/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import OpenAI from 'openai';
+import { Character, ImageModel } from '@/lib/types';
+import { incrementUsage, hasReachedLimit } from '@/lib/usage-limits';
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+  timeout: 120000, // 2 minutes timeout for image editing
+});
+
+// Maximum request size (50MB to handle large images for gpt-image-1)
+const MAX_REQUEST_SIZE = 50 * 1024 * 1024;
+
+// Only gpt-image-1 supports reliable image editing
+const EDIT_SUPPORTED_MODELS: ImageModel[] = ['gpt-image-1'];
+
+interface EditPortraitRequest {
+  character: Character;
+  editPrompt: string;
+  imageModel?: ImageModel;
+}
+
+interface EditPortraitResponse {
+  success: boolean;
+  character?: Character;
+  error?: string;
+  errorType?: string;
+}
+
+// Helper function to categorize errors
+const categorizeError = (error: any): { type: string; message: string; status: number } => {
+  if (error?.status || error?.code) {
+    const status = error.status;
+    const message = error.message || error.error?.message || 'Unknown API error';
+    
+    switch (status) {
+      case 429:
+        return {
+          type: 'rate_limit',
+          message: 'Rate limit exceeded. Please try again in a few minutes.',
+          status: 429
+        };
+      case 400:
+        if (message.toLowerCase().includes('prompt')) {
+          return {
+            type: 'invalid_request',
+            message: 'Edit description too long or invalid. Please try a shorter description.',
+            status: 400
+          };
+        }
+        if (message.toLowerCase().includes('image')) {
+          return {
+            type: 'invalid_request',
+            message: 'Image format or size not supported. Please try a different image.',
+            status: 400
+          };
+        }
+        return {
+          type: 'invalid_request',
+          message: 'Invalid request. Please check your edit description and image format.',
+          status: 400
+        };
+      case 401:
+        return {
+          type: 'authentication',
+          message: 'Authentication failed. Please check API configuration.',
+          status: 401
+        };
+      case 403:
+        return {
+          type: 'quota_exceeded',
+          message: 'Monthly quota exceeded for this model tier.',
+          status: 403
+        };
+      case 413:
+        return {
+          type: 'payload_too_large',
+          message: 'Image too large. Please try with a smaller image.',
+          status: 413
+        };
+      default:
+        return {
+          type: 'api_error',
+          message: `API error: ${message}`,
+          status: status || 500
+        };
+    }
+  }
+  
+  if (error?.name === 'AbortError' || error?.message?.includes('timeout')) {
+    return {
+      type: 'timeout',
+      message: 'Image editing timed out. Please try again.',
+      status: 408
+    };
+  }
+  
+  return {
+    type: 'unknown',
+    message: error?.message || 'An unexpected error occurred',
+    status: 500
+  };
+};
+
+// Helper function to validate edit prompt
+function validateEditPrompt(prompt: string, model: ImageModel): { isValid: boolean; error?: string } {
+  if (!prompt || typeof prompt !== 'string') {
+    return { isValid: false, error: 'Edit description is required' };
+  }
+  
+  const trimmedPrompt = prompt.trim();
+  if (trimmedPrompt.length === 0) {
+    return { isValid: false, error: 'Edit description cannot be empty' };
+  }
+  
+  // GPT-Image-1 supports up to 32,000 characters
+  const maxLength = 32000;
+  if (trimmedPrompt.length > maxLength) {
+    return { 
+      isValid: false, 
+      error: `Edit description is too long (max ${maxLength} characters)` 
+    };
+  }
+  
+  return { isValid: true };
+}
+
+// Helper function to validate image size
+function validateImageSize(imageData: string): { isValid: boolean; error?: string } {
+  // Remove data URL prefix to get base64 data
+  const base64Data = imageData.split(',')[1];
+  if (!base64Data) {
+    return { isValid: false, error: 'Invalid image data format' };
+  }
+  
+  // Estimate file size from base64 length
+  const sizeInBytes = (base64Data.length * 3) / 4;
+  const sizeInMB = sizeInBytes / (1024 * 1024);
+  
+  // GPT-Image-1 supports up to 50MB
+  const maxSize = 50;
+  
+  if (sizeInMB > maxSize) {
+    return { 
+      isValid: false, 
+      error: `Image too large (${sizeInMB.toFixed(2)}MB). Maximum size is ${maxSize}MB.` 
+    };
+  }
+  
+  return { isValid: true };
+}
+
+// Helper function to convert base64 data URL to File object
+function dataURLToFile(dataURL: string, filename: string = 'image.png'): File {
+  // Remove the data URL prefix (data:image/png;base64,)
+  const base64Data = dataURL.split(',')[1];
+  if (!base64Data) {
+    throw new Error('Invalid data URL format');
+  }
+  
+  // Convert to binary string then to Uint8Array
+  const binaryString = atob(base64Data);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  
+  // Create a File object
+  return new File([bytes], filename, { type: 'image/png' });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    // Check request size
+    const contentLength = request.headers.get('content-length');
+    if (contentLength && parseInt(contentLength) > MAX_REQUEST_SIZE) {
+      return NextResponse.json(
+        { 
+          success: false, 
+          error: 'Request too large. Please try with a smaller image.',
+          errorType: 'payload_too_large'
+        } as EditPortraitResponse,
+        { status: 413 }
+      );
+    }
+
+    const body: EditPortraitRequest = await request.json();
+    const { character, editPrompt, imageModel = 'gpt-image-1' } = body;
+    
+    // Validate that the model supports editing
+    if (!EDIT_SUPPORTED_MODELS.includes(imageModel)) {
+      return NextResponse.json(
+        { 
+          success: false, 
+          error: `${imageModel} doesn't support reliable image editing. Please use gpt-image-1.`,
+          errorType: 'unsupported_model'
+        } as EditPortraitResponse,
+        { status: 400 }
+      );
+    }
+    
+    // Validate request
+    if (!character) {
+      return NextResponse.json(
+        { 
+          success: false, 
+          error: 'Character data is required',
+          errorType: 'invalid_request'
+        } as EditPortraitResponse,
+        { status: 400 }
+      );
+    }
+    
+    if (!character.image_data && !character.image_url) {
+      return NextResponse.json(
+        { 
+          success: false, 
+          error: 'Character must have an existing portrait to edit',
+          errorType: 'invalid_request'
+        } as EditPortraitResponse,
+        { status: 400 }
+      );
+    }
+    
+    // Validate edit prompt
+    const promptValidation = validateEditPrompt(editPrompt, imageModel);
+    if (!promptValidation.isValid) {
+      return NextResponse.json(
+        { 
+          success: false, 
+          error: promptValidation.error,
+          errorType: 'invalid_request'
+        } as EditPortraitResponse,
+        { status: 400 }
+      );
+    }
+    
+    console.log(`Editing portrait for character: ${character.name}`);
+    console.log(`Edit prompt: "${editPrompt}"`);
+    console.log(`Using image model: ${imageModel}`);
+    
+    // Check usage limits BEFORE making API call
+    try {
+      if (hasReachedLimit(imageModel)) {
+        console.log(`Portrait editing blocked: Usage limit reached for ${imageModel}`);
+        return NextResponse.json(
+          { 
+            success: false, 
+            error: `Monthly limit reached for ${imageModel}. Please wait until next month.`,
+            errorType: 'quota_exceeded'
+          } as EditPortraitResponse,
+          { status: 403 }
+        );
+      }
+    } catch (limitError) {
+      console.warn('Error checking image model usage limits (continuing anyway):', limitError);
+    }
+    
+    try {
+      // Get the current image data
+      let imageData: string;
+      
+      if (character.image_data) {
+        imageData = character.image_data;
+      } else if (character.image_url) {
+        // Fetch image from URL and convert to data URL
+        const imageResponse = await fetch(character.image_url);
+        if (!imageResponse.ok) {
+          throw new Error(`Failed to fetch image: ${imageResponse.status}`);
+        }
+        const arrayBuffer = await imageResponse.arrayBuffer();
+        const base64 = Buffer.from(arrayBuffer).toString('base64');
+        imageData = `data:image/png;base64,${base64}`;
+      } else {
+        throw new Error('No image data available for editing');
+      }
+
+      // Validate image size
+      const sizeValidation = validateImageSize(imageData);
+      if (!sizeValidation.isValid) {
+        return NextResponse.json(
+          { 
+            success: false, 
+            error: sizeValidation.error,
+            errorType: 'invalid_request'
+          } as EditPortraitResponse,
+          { status: 400 }
+        );
+      }
+      
+      // Convert to File object
+      const imageFile = dataURLToFile(imageData, 'image.png');
+      
+      console.log(`Image file size: ${imageFile.size} bytes (${(imageFile.size / (1024 * 1024)).toFixed(2)}MB)`);
+      console.log(`Image file type: ${imageFile.type}`);
+      console.log(`Using OpenAI image editing endpoint with ${imageModel}`);
+      
+      // Prepare API parameters for GPT-Image-1
+      const editParams = {
+        model: imageModel,
+        image: imageFile,
+        prompt: editPrompt,
+        n: 1,
+        size: '1024x1024' as const,
+        quality: 'high' as const,
+        output_format: 'png' as const
+      };
+      
+      console.log('Edit parameters:', {
+        model: editParams.model,
+        promptLength: editParams.prompt.length,
+        size: editParams.size,
+        quality: editParams.quality,
+        output_format: editParams.output_format,
+        imageSize: `${(imageFile.size / (1024 * 1024)).toFixed(2)}MB`,
+        imageType: imageFile.type
+      });
+      
+      // Use the OpenAI image editing endpoint
+      const editResponse = await openai.images.edit(editParams);
+      
+      // Extract the image data (GPT-Image-1 returns base64 directly)
+      const b64Image = editResponse.data[0].b64_json;
+      if (!b64Image) {
+        throw new Error('No base64 image data returned from GPT-Image-1 editing');
+      }
+      
+      const editedImageData = `data:image/png;base64,${b64Image}`;
+      
+      // Validate the edited image data
+      if (!editedImageData.match(/^data:image\/[^;]+;base64,[A-Za-z0-9+/]*={0,2}$/)) {
+        throw new Error('Invalid base64 image data received from editing');
+      }
+      
+      // Increment usage count AFTER successful editing
+      try {
+        incrementUsage(imageModel);
+        console.log(`Successfully incremented usage for image model ${imageModel}`);
+      } catch (usageError) {
+        console.warn('Error incrementing image model usage (continuing anyway):', usageError);
+      }
+      
+      // Create updated character with the edited portrait
+      const updatedCharacter: Character = {
+        ...character,
+        image_data: editedImageData,
+        portrait_options: {
+          ...character.portrait_options,
+          image_model: imageModel
+        }
+      };
+      
+      console.log(`Successfully edited portrait for character: ${character.name} using ${imageModel}!`);
+      
+      return NextResponse.json({
+        success: true,
+        character: updatedCharacter
+      } as EditPortraitResponse);
+      
+    } catch (apiError) {
+      console.error('Image editing API error:', apiError);
+      
+      const errorInfo = categorizeError(apiError);
+      return NextResponse.json(
+        {
+          success: false,
+          error: errorInfo.message,
+          errorType: errorInfo.type
+        } as EditPortraitResponse,
+        { status: errorInfo.status }
+      );
+    }
+    
+  } catch (error) {
+    console.error('Request processing error:', error);
+    
+    const errorInfo = categorizeError(error);
+    
+    return NextResponse.json(
+      {
+        success: false,
+        error: errorInfo.message,
+        errorType: errorInfo.type
+      } as EditPortraitResponse,
+      { status: errorInfo.status }
+    );
+  }
+}

--- a/src/components/edit-page/additional-traits-section.tsx
+++ b/src/components/edit-page/additional-traits-section.tsx
@@ -1,36 +1,174 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Character } from '@/lib/types';
 import { FormSection } from './shared';
-import { PlusCircle, Trash2 } from 'lucide-react';
+import { PlusCircle, Trash2, RotateCcw, Sparkles } from 'lucide-react';
 import Button from '@/components/ui/button';
 
 interface AdditionalTraitsSectionProps {
   character: Character;
   setCharacter: React.Dispatch<React.SetStateAction<Character | null>>;
+  onRegenerate?: (field: string) => void;
+  isRegenerating?: boolean;
 }
 
 export const AdditionalTraitsSection = ({
   character,
-  setCharacter
+  setCharacter,
+  onRegenerate,
+  isRegenerating = false
 }: AdditionalTraitsSectionProps) => {
+  const [regeneratingTrait, setRegeneratingTrait] = useState<string | null>(null);
+
+  // Get all displayable additional traits (matching what shows in character modal)
+  const getDisplayableTraits = () => {
+    if (!character.added_traits) {
+      return {};
+    }
+    
+    const filtered: Record<string, string> = {};
+    
+    Object.entries(character.added_traits).forEach(([key, value]) => {
+      // Skip system/error traits and main profile fields
+      const isSystemTrait = key.includes('error') || 
+                           key.includes('fallback') || 
+                           key.includes('api') ||
+                           key.includes('portrait_') ||
+                           key === 'original_request' ||
+                           key === 'appearance' || 
+                           key === 'personality' || 
+                           key === 'backstory_hook';
+      
+      // Only include string values that aren't system traits and aren't empty after formatting
+      if (!isSystemTrait && typeof value === 'string' && value.trim().length > 0) {
+        // Apply the same formatting/filtering logic as the character modal
+        const formattedValue = value
+          .replace(/["""'']/g, '"')
+          .replace(/—/g, '-')
+          .replace(/…/g, '...')
+          .replace(/[^\w\s-.,!?]/g, '')
+          .trim();
+        
+        // Only include if it's not too long (same logic as character modal)
+        if (formattedValue.length <= 25 && 
+            !formattedValue.includes('.') && 
+            !formattedValue.includes(',') && 
+            formattedValue.split(' ').length <= 4) {
+          
+          // Capitalize properly
+          const capitalizedValue = formattedValue
+            .split(' ')
+            .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+            .join(' ');
+          
+          filtered[key] = capitalizedValue;
+        }
+      }
+    });
+    
+    return filtered;
+  };
+
+  const displayableTraits = getDisplayableTraits();
+
   const handleAddTrait = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     e.stopPropagation();
     
     // Create a unique key for the new trait
-    const newTraitKey = `custom_trait_${Object.keys(character.added_traits).length + 1}`;
+    const existingKeys = Object.keys(character.added_traits || {});
+    let counter = 1;
+    let newTraitKey = `custom_trait_${counter}`;
+    
+    // Ensure the key is unique
+    while (existingKeys.includes(newTraitKey)) {
+      counter++;
+      newTraitKey = `custom_trait_${counter}`;
+    }
     
     setCharacter({
       ...character,
       added_traits: {
         ...character.added_traits,
-        [newTraitKey]: "New trait value"
+        [newTraitKey]: "New Trait"
       }
     });
   };
-  
+
+  const handleAddGeneratedTrait = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    
+    if (onRegenerate) {
+      onRegenerate('add_single_trait');
+    }
+  };
+
+  const handleRegenerateTrait = (traitKey: string) => {
+    if (onRegenerate) {
+      setRegeneratingTrait(traitKey);
+      onRegenerate(`regenerate_trait_${traitKey}`);
+    }
+  };
+
+  const handleTraitKeyChange = (oldKey: string, newKey: string) => {
+    if (oldKey === newKey) return;
+    
+    // Create a new object without the old key but with the new key
+    const newTraits = { ...character.added_traits };
+    const oldValue = newTraits[oldKey];
+    delete newTraits[oldKey];
+    
+    // Only add the new key if it's not empty and doesn't already exist
+    if (newKey.trim() && !newTraits[newKey]) {
+      newTraits[newKey] = oldValue;
+    } else if (newKey.trim()) {
+      // If key exists, append a number
+      let counter = 1;
+      let uniqueKey = `${newKey}_${counter}`;
+      while (newTraits[uniqueKey]) {
+        counter++;
+        uniqueKey = `${newKey}_${counter}`;
+      }
+      newTraits[uniqueKey] = oldValue;
+    } else {
+      // If new key is empty, use a default
+      newTraits['trait'] = oldValue;
+    }
+    
+    setCharacter({
+      ...character,
+      added_traits: newTraits
+    });
+  };
+
+  const handleTraitValueChange = (key: string, newValue: string) => {
+    setCharacter({
+      ...character,
+      added_traits: {
+        ...character.added_traits,
+        [key]: newValue
+      }
+    });
+  };
+
+  const handleRemoveTrait = (keyToRemove: string) => {
+    const newTraits = { ...character.added_traits };
+    delete newTraits[keyToRemove];
+    setCharacter({
+      ...character,
+      added_traits: newTraits
+    });
+  };
+
+  // Clear regenerating state when regeneration completes
+  React.useEffect(() => {
+    if (!isRegenerating) {
+      setRegeneratingTrait(null);
+    }
+  }, [isRegenerating]);
+
   return (
     <FormSection title="Additional Traits">
       <p className="text-sm text-muted mb-4">
@@ -38,68 +176,62 @@ export const AdditionalTraitsSection = ({
       </p>
       
       <div className="space-y-3">
-        {/* List of existing AI-added traits */}
-        {Object.entries(character.added_traits).map(([key, value], index) => (
-          <div key={index} className="flex items-center gap-3 pb-3 border-b border-gray-200 dark:border-gray-700 last:border-0 last:mb-0 last:pb-0">
-            <div className="w-1/3">
-              <input
-                type="text"
-                value={key}
-                onChange={(e) => {
-                  // Create a new object without the old key but with the new key
-                  const newTraits = { ...character.added_traits };
-                  const oldValue = newTraits[key];
-                  delete newTraits[key];
-                  newTraits[e.target.value] = oldValue;
-                  
-                  setCharacter({
-                    ...character,
-                    added_traits: newTraits
-                  });
+        {/* List of existing additional traits */}
+        {Object.entries(displayableTraits).length > 0 ? (
+          Object.entries(displayableTraits).map(([key, value], index) => (
+            <div key={`${key}-${index}`} className="flex items-center gap-3 pb-3 border-b border-gray-200 dark:border-gray-700 last:border-0 last:mb-0 last:pb-0">
+              <div className="w-1/4">
+                <input
+                  type="text"
+                  value={key.replace(/_/g, ' ')} // Display with spaces for readability
+                  onChange={(e) => {
+                    const newKey = e.target.value.replace(/\s+/g, '_').toLowerCase(); // Convert back to underscore format
+                    handleTraitKeyChange(key, newKey);
+                  }}
+                  placeholder="Trait name"
+                  className="w-full p-2 border border-theme rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-secondary"
+                />
+              </div>
+              <div className="flex-1">
+                <input
+                  type="text"
+                  value={value}
+                  onChange={(e) => handleTraitValueChange(key, e.target.value)}
+                  placeholder="Trait value"
+                  className="w-full p-2 border border-theme rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-secondary"
+                />
+              </div>
+              <button
+                type="button"
+                onClick={() => handleRegenerateTrait(key)}
+                disabled={regeneratingTrait === key}
+                className="p-2 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors disabled:opacity-50"
+                title="Regenerate this trait"
+              >
+                <RotateCcw className={`h-4 w-4 ${regeneratingTrait === key ? 'animate-spin' : ''}`} />
+              </button>
+              <button
+                type="button"
+                onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  handleRemoveTrait(key);
                 }}
-                placeholder="Trait name"
-                className="w-full p-2 border border-theme rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-secondary"
-              />
+                className="p-2 text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 transition-colors"
+                title="Remove trait"
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
             </div>
-            <div className="flex-1">
-              <input
-                type="text"
-                value={value}
-                onChange={(e) => {
-                  setCharacter({
-                    ...character,
-                    added_traits: {
-                      ...character.added_traits,
-                      [key]: e.target.value
-                    }
-                  });
-                }}
-                placeholder="Trait value"
-                className="w-full p-2 border border-theme rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-secondary"
-              />
-            </div>
-            <button
-              type="button"
-              onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-                e.preventDefault();
-                e.stopPropagation();
-                const newTraits = { ...character.added_traits };
-                delete newTraits[key];
-                setCharacter({
-                  ...character,
-                  added_traits: newTraits
-                });
-              }}
-              className="p-2 text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
-              title="Remove trait"
-            >
-              <Trash2 className="h-5 w-5" />
-            </button>
+          ))
+        ) : (
+          <div className="text-sm text-gray-500 dark:text-gray-400 py-4 text-center border border-dashed border-gray-300 dark:border-gray-600 rounded-lg">
+            No additional traits found. Add custom traits or generate new ones using the buttons below.
           </div>
-        ))}
+        )}
         
-        {/* Add new trait button */}
-        <div className="mt-4">
+        {/* Action buttons */}
+        <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700 flex gap-3">
           <Button
             variant="secondary"
             onClick={handleAddTrait}
@@ -108,6 +240,18 @@ export const AdditionalTraitsSection = ({
           >
             Add Custom Trait
           </Button>
+          
+          {onRegenerate && (
+            <Button
+              variant="secondary"
+              onClick={handleAddGeneratedTrait}
+              disabled={isRegenerating}
+              leftIcon={<Sparkles className={`h-4 w-4 ${isRegenerating && regeneratingTrait === null ? 'animate-pulse' : ''}`} />}
+              type="button"
+            >
+              {isRegenerating && regeneratingTrait === null ? 'Generating...' : 'Add Generated Trait'}
+            </Button>
+          )}
         </div>
       </div>
     </FormSection>

--- a/src/components/edit-page/portrait-section.tsx
+++ b/src/components/edit-page/portrait-section.tsx
@@ -2,12 +2,12 @@
 'use client';
 
 import React, { useState } from 'react';
-import { Character } from '@/lib/types';
+import { Character, ImageModel } from '@/lib/types';
 import PortraitDisplay from '@/components/portrait-display';
 import ImageUpload from '@/components/image-upload';
 import { FormSection } from './shared';
 import Button from '@/components/ui/button';
-import { AlertTriangle, RefreshCw, Info, CheckCircle, Upload, RotateCcw } from 'lucide-react';
+import { AlertTriangle, RefreshCw, Info, CheckCircle, Upload, RotateCcw, Edit3, Wand2 } from 'lucide-react';
 
 interface PortraitSectionProps {
   character: Character;
@@ -20,7 +20,13 @@ interface PortraitSectionProps {
   portraitGenerationFailed?: boolean;
   portraitShouldRetry?: boolean;
   portraitErrorType?: 'quota_exceeded' | 'rate_limit' | 'timeout' | 'network' | 'server' | 'unknown' | null;
+  selectedImageModel: ImageModel;
+  setCharacter: (character: Character | ((prev: Character) => Character)) => void;
 }
+
+// Models that support image editing (according to OpenAI API docs)
+// Note: DALL-E 2 editing is unreliable despite meeting all documented requirements
+const EDIT_SUPPORTED_MODELS: ImageModel[] = ['gpt-image-1'];
 
 export function PortraitSection({
   character,
@@ -32,18 +38,121 @@ export function PortraitSection({
   portraitError,
   portraitGenerationFailed = false,
   portraitShouldRetry = false,
-  portraitErrorType = null
+  portraitErrorType = null,
+  selectedImageModel,
+  setCharacter
 }: PortraitSectionProps) {
   const [showImageUpload, setShowImageUpload] = useState(false);
+  const [showEditPrompt, setShowEditPrompt] = useState(false);
+  const [editPrompt, setEditPrompt] = useState('');
+  const [isEditingPortrait, setIsEditingPortrait] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
 
   const handleToggleImageUpload = () => {
     setShowImageUpload(!showImageUpload);
+    if (showEditPrompt) setShowEditPrompt(false);
+  };
+
+  const handleToggleEditPrompt = () => {
+    setShowEditPrompt(!showEditPrompt);
+    if (showImageUpload) setShowImageUpload(false);
+    setEditError(null);
   };
 
   const handleImageChange = (imageData: string | null) => {
     if (imageData) {
       onImageChange(imageData);
       setShowImageUpload(false);
+    }
+  };
+
+  const handleEditPortrait = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    
+    if (!editPrompt.trim()) {
+      setEditError('Please enter an edit prompt');
+      return;
+    }
+    
+    if (!character.image_data && !character.image_url) {
+      setEditError('No existing portrait to edit');
+      return;
+    }
+
+    // Check if selected model supports editing
+    if (!EDIT_SUPPORTED_MODELS.includes(selectedImageModel)) {
+      setEditError(`${selectedImageModel} doesn't support image editing. Please switch to dall-e-2 or gpt-image-1.`);
+      return;
+    }
+    
+    setIsEditingPortrait(true);
+    setEditError(null);
+    
+    try {
+      console.log(`Editing portrait with prompt: "${editPrompt}" using model: ${selectedImageModel}`);
+      
+      const response = await fetch('/api/edit-portrait', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          character: character,
+          editPrompt: editPrompt.trim(),
+          imageModel: selectedImageModel
+        }),
+      });
+
+      if (!response.ok) {
+        let errorMessage = 'Failed to edit portrait';
+        try {
+          const errorData = await response.json();
+          console.error("Portrait edit API error response:", errorData);
+          errorMessage = errorData.error || errorMessage;
+          
+          // Handle specific error types
+          if (errorData.errorType === 'rate_limit') {
+            errorMessage = 'Rate limit exceeded. Please try again in a few minutes.';
+          } else if (errorData.errorType === 'quota_exceeded') {
+            errorMessage = 'Monthly quota exceeded for this model tier.';
+          } else if (errorData.errorType === 'invalid_request') {
+            errorMessage = 'Invalid edit request. Please try a different prompt.';
+          } else if (errorData.errorType === 'timeout') {
+            errorMessage = 'Portrait editing timed out. Please try again.';
+          } else if (errorData.errorType === 'unsupported_model') {
+            errorMessage = `${selectedImageModel} doesn't support editing. Switch to dall-e-2 or gpt-image-1.`;
+          }
+        } catch (parseError) {
+          console.error("Failed to parse error response:", parseError);
+        }
+        
+        setEditError(errorMessage);
+        return;
+      }
+
+      const result = await response.json();
+      console.log("Portrait edit result:", result);
+
+      if (result.success && result.character && result.character.image_data) {
+        console.log("Portrait edited successfully");
+        
+        // Update character with edited portrait
+        setCharacter(result.character);
+        
+        // Clear the edit prompt and hide the edit interface
+        setEditPrompt('');
+        setShowEditPrompt(false);
+        
+        console.log('Portrait editing completed successfully');
+      } else {
+        throw new Error('Invalid response format');
+      }
+    } catch (err) {
+      console.error("Error editing portrait:", err);
+      setEditError('Failed to edit portrait. Please try again.');
+    } finally {
+      setIsEditingPortrait(false);
     }
   };
 
@@ -87,6 +196,8 @@ export function PortraitSection({
   };
 
   const errorInfo = portraitGenerationFailed && portraitError ? getErrorInfo(portraitErrorType) : null;
+  const hasExistingPortrait = !!(character.image_data || character.image_url);
+  const editSupported = EDIT_SUPPORTED_MODELS.includes(selectedImageModel);
 
   return (
     <FormSection title="Character Portrait">
@@ -99,6 +210,23 @@ export function PortraitSection({
               <p className="text-sm text-amber-800 dark:text-amber-200">
                 <strong>Unsaved changes.</strong> Remember to save your modifications.
               </p>
+            </div>
+          </div>
+        )}
+
+        {/* Model compatibility warning for editing */}
+        {!editSupported && (
+          <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-3">
+            <div className="flex items-start gap-2">
+              <Info className="h-4 w-4 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-blue-800 dark:text-blue-200 mb-1">
+                  Portrait Editing Not Available
+                </p>
+                <p className="text-sm text-blue-700 dark:text-blue-300">
+                  <strong>{selectedImageModel}</strong> doesn't support reliable image editing. Switch to <strong>gpt-image-1</strong> above to enable portrait editing.
+                </p>
+              </div>
             </div>
           </div>
         )}
@@ -121,6 +249,62 @@ export function PortraitSection({
                 Cancel Upload
               </Button>
             </div>
+          ) : showEditPrompt ? (
+            <div className="w-full max-w-md space-y-3">
+              <div className="space-y-2">
+                <label htmlFor="edit-prompt" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Edit Portrait with OpenAI
+                </label>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                  Uses OpenAI's image editing API to modify your existing portrait. Only works with dall-e-2 and gpt-image-1.
+                </p>
+                <textarea
+                  id="edit-prompt"
+                  value={editPrompt}
+                  onChange={(e) => setEditPrompt(e.target.value)}
+                  placeholder="Describe what you want to change... (e.g., 'add a red hat', 'remove glasses', 'change hair color to blonde', 'add a beard')"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 resize-y min-h-[80px]"
+                  rows={3}
+                  maxLength={selectedImageModel === 'gpt-image-1' ? 32000 : 1000}
+                  disabled={isEditingPortrait}
+                />
+                <div className="text-xs text-gray-500 dark:text-gray-400">
+                  {editPrompt.length}/{selectedImageModel === 'gpt-image-1' ? '32,000' : '1,000'} characters
+                </div>
+              </div>
+              
+              <div className="flex gap-2">
+                <Button
+                  onClick={handleEditPortrait}
+                  disabled={isEditingPortrait || !editPrompt.trim() || !hasExistingPortrait || !editSupported}
+                  type="button"
+                  className="flex-1"
+                >
+                  <Wand2 className="h-4 w-4 mr-2" />
+                  {isEditingPortrait ? 'Editing Image...' : 'Edit Portrait'}
+                </Button>
+                <Button
+                  variant="secondary"
+                  onClick={handleToggleEditPrompt}
+                  disabled={isEditingPortrait}
+                  type="button"
+                >
+                  Cancel
+                </Button>
+              </div>
+              
+              {!hasExistingPortrait && (
+                <p className="text-sm text-gray-500 dark:text-gray-400 text-center">
+                  Upload or generate a portrait first to enable editing
+                </p>
+              )}
+
+              {!editSupported && (
+                <p className="text-sm text-gray-500 dark:text-gray-400 text-center">
+                  Switch to dall-e-2 or gpt-image-1 to enable editing
+                </p>
+              )}
+            </div>
           ) : (
             <>
               {/* Portrait Display */}
@@ -131,25 +315,40 @@ export function PortraitSection({
                   characterId={characterId}
                   name={character.name}
                   size="large"
-                  isLoading={isRegeneratingPortrait}
+                  isLoading={isRegeneratingPortrait || isEditingPortrait}
                   className="w-full"
                 />
               </div>
 
               {/* Action Buttons */}
-              <div className="flex gap-3">
+              <div className="flex flex-wrap gap-2 justify-center">
                 <Button
                   variant="secondary"
                   onClick={onRegeneratePortrait}
-                  disabled={isRegeneratingPortrait}
+                  disabled={isRegeneratingPortrait || isEditingPortrait}
                   type="button"
                 >
                   <RotateCcw className="h-4 w-4 mr-2" />
                   {isRegeneratingPortrait ? 'Generating...' : 'Regenerate'}
                 </Button>
+                
+                {hasExistingPortrait && (
+                  <Button
+                    variant="secondary"
+                    onClick={handleToggleEditPrompt}
+                    disabled={isRegeneratingPortrait || isEditingPortrait || !editSupported}
+                    type="button"
+                    title={!editSupported ? `${selectedImageModel} doesn't support editing. Use dall-e-2 or gpt-image-1.` : 'Edit existing portrait'}
+                  >
+                    <Edit3 className="h-4 w-4 mr-2" />
+                    Edit Portrait
+                  </Button>
+                )}
+                
                 <Button
                   variant="secondary"
                   onClick={handleToggleImageUpload}
+                  disabled={isRegeneratingPortrait || isEditingPortrait}
                   type="button"
                 >
                   <Upload className="h-4 w-4 mr-2" />
@@ -162,18 +361,35 @@ export function PortraitSection({
         
         {/* Status Messages */}
         {/* Generation Status */}
-        {isRegeneratingPortrait && (
+        {(isRegeneratingPortrait || isEditingPortrait) && (
           <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-3">
             <div className="flex items-center gap-2">
               <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600 dark:border-blue-400"></div>
               <p className="text-sm font-medium text-blue-800 dark:text-blue-200">
-                Generating new portrait...
+                {isRegeneratingPortrait ? 'Generating new portrait...' : 'Editing portrait with OpenAI...'}
               </p>
             </div>
           </div>
         )}
 
-        {/* Error Display */}
+        {/* Edit Error Display */}
+        {editError && (
+          <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3">
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="h-4 w-4 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-red-800 dark:text-red-200 mb-1">
+                  Portrait Editing Failed
+                </p>
+                <p className="text-sm text-red-700 dark:text-red-300">
+                  {editError}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Generation Error Display */}
         {portraitGenerationFailed && errorInfo && (
           <div className={`p-3 rounded-lg border ${errorInfo.bgColor} ${errorInfo.borderColor}`}>
             <div className="flex items-start gap-2">
@@ -198,7 +414,7 @@ export function PortraitSection({
         )}
 
         {/* Success Message */}
-        {!isRegeneratingPortrait && !portraitGenerationFailed && (character.image_data || character.image_url) && (
+        {!isRegeneratingPortrait && !isEditingPortrait && !portraitGenerationFailed && hasExistingPortrait && (
           <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-3">
             <div className="flex items-center gap-2">
               <CheckCircle className="h-4 w-4 text-green-600 dark:text-green-400 flex-shrink-0" />


### PR DESCRIPTION
## Summary
This PR introduces AI-powered portrait editing using prompt-based instructions, along with trait regeneration tools to enrich character creation. Additional polish was applied across the trait system and navigation flow.

## Changelog

### Added
- AI-powered portrait editing via text prompts using OpenAI’s `/v1/images/edits` endpoint (supports `gpt-image-1`)
- "Add Generated Trait" button in Additional Traits section to generate a new short trait via AI
- Individual regenerate buttons for each trait in the Additional Traits section

### Changed
- Trait filtering now excludes long or sentence-like traits entirely (instead of truncating them)
- Trait formatting standardized to Title Case throughout the UI
- Additional Traits display logic now matches exactly between the character modal and edit page
- Navigation back to the Library after saving changes is now immediate with no artificial delay

### Fixed
- Traits missing from the edit page but visible in the modal due to inconsistent filtering logic
