### PR TITLE
Implement documentation improvements and regenerate UX fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Developer Documentation homepage at `/docs/developer` with dedicated navigation and sidebar highlighting
+- Clickable "Developer Docs" section in sidebar with breadcrumb-aware expansion and sub-page structure
+- Visual loading indicators for regeneration across all edit page sections (not just traits)
+- "Save to Library" → "View Library" dynamic button transition in character generation results step
+
+### Changed
+- Sidebar component refactored to integrate "Chat with Characters" link and fully support developer documentation section navigation
+- Docs homepage updated to feature main docs and a link to the developer docs landing page
+- Additional Traits section updated to:
+  - Capitalize category names
+  - Display all traits not included in the Basic Info or Character Traits sections
+  - Include unsupported traits (e.g. custom personality entries)
+- Regenerate button icon reverted to rotating circle (`RotateCcw`) for visual consistency across all edit sections
+- Portrait section messaging updated to clarify that only `gpt-image-1` supports editing; DALL·E 2 and 3 do not
+- Enhanced breadcrumb navigation under `/docs` to reflect correct hierarchy for developer documentation pages
+
+### Fixed
+- Quest regeneration fallback logic improved to handle malformed or non-JSON responses gracefully
+- Visual regeneration states now correctly trigger for dialogue, items, quests, and basic info sections
+- Developer docs sidebar section now properly expands and highlights based on active route
+- Duplicate portrait regeneration status messages removed
+
 ## [0.21.0] - 2025-06-12
 
 ### Added

--- a/src/app/docs/developer/page.tsx
+++ b/src/app/docs/developer/page.tsx
@@ -1,0 +1,183 @@
+import Link from 'next/link';
+import { Code, Server, ShieldCheck, FileText, Bell, CodeSquare } from 'lucide-react';
+
+export const metadata = {
+  title: 'Developer Documentation - NPC Forge',
+  description: 'Developer documentation for NPC Forge: setup, architecture, API reference, and contribution guidelines.',
+};
+
+export default function DeveloperDocsPage() {
+  return (
+    <div className="max-w-4xl mx-auto">
+      <h1 className="text-3xl font-bold mb-6 text-gray-900 dark:text-gray-100">Developer Documentation</h1>
+      
+      <p className="lead mb-8 text-gray-700 dark:text-gray-300 text-lg">
+        Welcome to the NPC Forge developer documentation. Here you'll find technical guides, API references, and contribution guidelines for developers who want to work with, extend, or contribute to NPC Forge.
+      </p>
+      
+      <div className="mb-10">
+        <h2 className="text-2xl font-semibold mb-6 text-indigo-700 dark:text-indigo-400 flex items-center">
+          <Code className="h-5 w-5 mr-2" />
+          Getting Started
+        </h2>
+        
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="p-4 border border-gray-200 rounded-lg shadow-sm dark:border-gray-700">
+            <h3 className="text-lg font-medium mb-3 text-indigo-700 dark:text-indigo-400 flex items-center">
+              <CodeSquare className="h-5 w-5 mr-2 text-indigo-600 dark:text-indigo-400" />
+              <Link href="/docs/dev-setup" className="hover:text-indigo-800 dark:hover:text-indigo-300">
+                Development Setup
+              </Link>
+            </h3>
+            <p className="text-gray-700 dark:text-gray-300">
+              Local environment setup, prerequisites, and project configuration for development.
+            </p>
+          </div>
+          
+          <div className="p-4 border border-gray-200 rounded-lg shadow-sm dark:border-gray-700">
+            <h3 className="text-lg font-medium mb-3 text-indigo-700 dark:text-indigo-400 flex items-center">
+              <CodeSquare className="h-5 w-5 mr-2 text-indigo-600 dark:text-indigo-400" />
+              <Link href="/docs/architecture" className="hover:text-indigo-800 dark:hover:text-indigo-300">
+                Architecture Overview
+              </Link>
+            </h3>
+            <p className="text-gray-700 dark:text-gray-300">
+              System structure, chat system architecture, component organization, and data flow.
+            </p>
+          </div>
+        </div>
+      </div>
+      
+      <div className="mb-10">
+        <h2 className="text-2xl font-semibold mb-6 text-indigo-700 dark:text-indigo-400 flex items-center">
+          <Server className="h-5 w-5 mr-2" />
+          API & Integration
+        </h2>
+        
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="p-4 border border-gray-200 rounded-lg shadow-sm dark:border-gray-700">
+            <h3 className="text-lg font-medium mb-3 text-indigo-700 dark:text-indigo-400 flex items-center">
+              <Server className="h-5 w-5 mr-2 text-indigo-600 dark:text-indigo-400" />
+              <Link href="/docs/api" className="hover:text-indigo-800 dark:hover:text-indigo-300">
+                API Reference
+              </Link>
+            </h3>
+            <p className="text-gray-700 dark:text-gray-300">
+              Complete API documentation including chat endpoints, generation, and OpenAI integration.
+            </p>
+          </div>
+          
+          <div className="p-4 border border-gray-200 rounded-lg shadow-sm dark:border-gray-700">
+            <h3 className="text-lg font-medium mb-3 text-indigo-700 dark:text-indigo-400 flex items-center">
+              <ShieldCheck className="h-5 w-5 mr-2 text-indigo-600 dark:text-indigo-400" />
+              <Link href="/docs/security" className="hover:text-indigo-800 dark:hover:text-indigo-300">
+                Security Documentation
+              </Link>
+            </h3>
+            <p className="text-gray-700 dark:text-gray-300">
+              Input validation, data privacy practices, and security considerations for chat and storage.
+            </p>
+          </div>
+        </div>
+      </div>
+      
+      <div className="mb-10">
+        <h2 className="text-2xl font-semibold mb-6 text-indigo-700 dark:text-indigo-400 flex items-center">
+          <FileText className="h-5 w-5 mr-2" />
+          Contributing
+        </h2>
+        
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="p-4 border border-gray-200 rounded-lg shadow-sm dark:border-gray-700">
+            <h3 className="text-lg font-medium mb-3 text-indigo-700 dark:text-indigo-400 flex items-center">
+              <FileText className="h-5 w-5 mr-2 text-indigo-600 dark:text-indigo-400" />
+              <Link href="/docs/contributing" className="hover:text-indigo-800 dark:hover:text-indigo-300">
+                Contributing Guidelines
+              </Link>
+            </h3>
+            <p className="text-gray-700 dark:text-gray-300">
+              How to contribute code, documentation, and report issues for the project.
+            </p>
+          </div>
+          
+          <div className="p-4 border border-gray-200 rounded-lg shadow-sm dark:border-gray-700">
+            <h3 className="text-lg font-medium mb-3 text-indigo-700 dark:text-indigo-400 flex items-center">
+              <Bell className="h-5 w-5 mr-2 text-indigo-600 dark:text-indigo-400" />
+              <Link href="/docs/testing" className="hover:text-indigo-800 dark:hover:text-indigo-300">
+                Testing Guide
+              </Link>
+            </h3>
+            <p className="text-gray-700 dark:text-gray-300">
+              Manual testing procedures, chat testing workflows, and quality assurance practices.
+            </p>
+          </div>
+        </div>
+      </div>
+      
+      <div className="p-4 bg-indigo-50 rounded-lg border border-indigo-200 dark:bg-indigo-900/20 dark:border-indigo-800 mb-8">
+        <h2 className="text-xl font-semibold mb-2 text-indigo-700 dark:text-indigo-300">Quick Start for Developers</h2>
+        <p className="mb-4 text-indigo-600 dark:text-indigo-400">
+          New to NPC Forge development? Follow these steps to get started:
+        </p>
+        <ol className="list-decimal list-inside space-y-1 text-indigo-600 dark:text-indigo-400">
+          <li>
+            <Link href="/docs/dev-setup" className="underline hover:text-indigo-800 dark:hover:text-indigo-300">
+              Set up your development environment
+            </Link>
+            {" "}with Node.js, dependencies, and environment variables
+          </li>
+          <li>
+            <Link href="/docs/architecture" className="underline hover:text-indigo-800 dark:hover:text-indigo-300">
+              Review the system architecture
+            </Link>
+            {" "}to understand how components interact
+          </li>
+          <li>
+            <Link href="/docs/api" className="underline hover:text-indigo-800 dark:hover:text-indigo-300">
+              Explore the API endpoints
+            </Link>
+            {" "}for character generation, chat, and management
+          </li>
+          <li>
+            <Link href="/docs/contributing" className="underline hover:text-indigo-800 dark:hover:text-indigo-300">
+              Read the contribution guidelines
+            </Link>
+            {" "}before making changes or submitting PRs
+          </li>
+          <li>
+            <Link href="/docs/testing" className="underline hover:text-indigo-800 dark:hover:text-indigo-300">
+              Learn the testing procedures
+            </Link>
+            {" "}to ensure quality and reliability
+          </li>
+        </ol>
+      </div>
+      
+      <div className="mb-8">
+        <h2 className="text-2xl font-semibold mb-4 text-indigo-700 dark:text-indigo-400">Technical Overview</h2>
+        
+        <div className="prose prose-lg dark:prose-invert max-w-none">
+          <p className="text-gray-700 dark:text-gray-300">
+            NPC Forge is built with modern web technologies and follows best practices for scalability, 
+            maintainability, and performance. The application uses:
+          </p>
+          
+          <ul className="text-gray-700 dark:text-gray-300 list-disc list-inside space-y-1 mt-4">
+            <li><strong>Next.js 14</strong> with App Router for server-side rendering and routing</li>
+            <li><strong>TypeScript</strong> for type safety and better developer experience</li>
+            <li><strong>Tailwind CSS</strong> for utility-first styling and responsive design</li>
+            <li><strong>IndexedDB</strong> for client-side data persistence and chat storage</li>
+            <li><strong>OpenAI API</strong> for character generation, chat, and portrait editing</li>
+            <li><strong>React Context</strong> for state management across components</li>
+          </ul>
+          
+          <p className="text-gray-700 dark:text-gray-300 mt-4">
+            The application is designed to be modular, with clear separation of concerns between 
+            UI components, data management, and API interactions. This makes it easy to extend 
+            functionality, add new features, and maintain code quality.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link';
-import { Book, Code, User, FileText, Settings, HelpCircle, Calendar, Map, ShieldCheck, CodeSquare, Bell, Layers, Server, FileJson, Award, Database, MessageCircle } from 'lucide-react';
+import { Book, User, FileText, Settings, HelpCircle, Database, MessageCircle, Layers, Server, Code, ArrowRight } from 'lucide-react';
 
 export const metadata = {
   title: 'NPC Forge Documentation',
-  description: 'Official NPC Forge documentation hub: guides, examples, and developer references for AI-powered character creation and interactive conversations.',
+  description: 'Official NPC Forge documentation hub: guides, examples, and references for AI-powered character creation and interactive conversations.',
 };
 
 export default function DocsIndexPage() {
@@ -12,7 +12,7 @@ export default function DocsIndexPage() {
       <h1 className="text-3xl font-bold mb-6 text-gray-900 dark:text-gray-100">NPC Forge Documentation</h1>
       
       <p className="lead mb-8 text-gray-700 dark:text-gray-300 text-lg">
-        Welcome to the NPC Forge documentation. Here you'll find comprehensive guides, examples, and developer references to help you get the most out of this AI-powered character generator with interactive chat capabilities.
+        Welcome to the NPC Forge documentation. Here you'll find comprehensive guides and references to help you get the most out of this AI-powered character generator with interactive chat capabilities.
       </p>
       
       <div className="mb-10">
@@ -126,122 +126,24 @@ export default function DocsIndexPage() {
           Developer Documentation
         </h2>
         
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div className="p-4 border border-gray-200 rounded-lg shadow-sm dark:border-gray-700">
-            <h3 className="text-lg font-medium mb-3 text-indigo-700 dark:text-indigo-400 flex items-center">
-              <CodeSquare className="h-5 w-5 mr-2 text-indigo-600 dark:text-indigo-400" />
-              <Link href="/docs/dev-setup" className="hover:text-indigo-800 dark:hover:text-indigo-300">
-                Development Setup
+        <div className="p-6 border border-gray-200 rounded-lg shadow-sm dark:border-gray-700 bg-gradient-to-r from-indigo-50 to-blue-50 dark:from-indigo-900/20 dark:to-blue-900/20">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-xl font-medium mb-2 text-indigo-700 dark:text-indigo-400 flex items-center">
+                <Code className="h-6 w-6 mr-2 text-indigo-600 dark:text-indigo-400" />
+                Technical Documentation
+              </h3>
+              <p className="text-gray-700 dark:text-gray-300 mb-4">
+                Complete developer resources including setup guides, architecture documentation, API references, and contribution guidelines.
+              </p>
+              <Link 
+                href="/docs/developer" 
+                className="inline-flex items-center px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg transition-colors"
+              >
+                View Developer Docs
+                <ArrowRight className="h-4 w-4 ml-2" />
               </Link>
-            </h3>
-            <p className="text-gray-700 dark:text-gray-300">
-              Local environment setup, prerequisites, and project configuration for development.
-            </p>
-          </div>
-          
-          <div className="p-4 border border-gray-200 rounded-lg shadow-sm dark:border-gray-700">
-            <h3 className="text-lg font-medium mb-3 text-indigo-700 dark:text-indigo-400 flex items-center">
-              <Layers className="h-5 w-5 mr-2 text-indigo-600 dark:text-indigo-400" />
-              <Link href="/docs/architecture" className="hover:text-indigo-800 dark:hover:text-indigo-300">
-                Architecture Overview
-              </Link>
-            </h3>
-            <p className="text-gray-700 dark:text-gray-300">
-              System structure, chat system architecture, component organization, and data flow.
-            </p>
-          </div>
-          
-          <div className="p-4 border border-gray-200 rounded-lg shadow-sm dark:border-gray-700">
-            <h3 className="text-lg font-medium mb-3 text-indigo-700 dark:text-indigo-400 flex items-center">
-              <Server className="h-5 w-5 mr-2 text-indigo-600 dark:text-indigo-400" />
-              <Link href="/docs/api" className="hover:text-indigo-800 dark:hover:text-indigo-300">
-                API Reference
-              </Link>
-            </h3>
-            <p className="text-gray-700 dark:text-gray-300">
-              Complete API documentation including chat endpoints, generation, and OpenAI integration.
-            </p>
-          </div>
-          
-          <div className="p-4 border border-gray-200 rounded-lg shadow-sm dark:border-gray-700">
-            <h3 className="text-lg font-medium mb-3 text-indigo-700 dark:text-indigo-400 flex items-center">
-              <ShieldCheck className="h-5 w-5 mr-2 text-indigo-600 dark:text-indigo-400" />
-              <Link href="/docs/security" className="hover:text-indigo-800 dark:hover:text-indigo-300">
-                Security Documentation
-              </Link>
-            </h3>
-            <p className="text-gray-700 dark:text-gray-300">
-              Input validation, data privacy practices, and security considerations for chat and storage.
-            </p>
-          </div>
-          
-          <div className="p-4 border border-gray-200 rounded-lg shadow-sm dark:border-gray-700">
-            <h3 className="text-lg font-medium mb-3 text-indigo-700 dark:text-indigo-400 flex items-center">
-              <FileText className="h-5 w-5 mr-2 text-indigo-600 dark:text-indigo-400" />
-              <Link href="/docs/contributing" className="hover:text-indigo-800 dark:hover:text-indigo-300">
-                Contributing Guidelines
-              </Link>
-            </h3>
-            <p className="text-gray-700 dark:text-gray-300">
-              How to contribute code, documentation, and report issues for the project.
-            </p>
-          </div>
-          
-          <div className="p-4 border border-gray-200 rounded-lg shadow-sm dark:border-gray-700">
-            <h3 className="text-lg font-medium mb-3 text-indigo-700 dark:text-indigo-400 flex items-center">
-              <Bell className="h-5 w-5 mr-2 text-indigo-600 dark:text-indigo-400" />
-              <Link href="/docs/testing" className="hover:text-indigo-800 dark:hover:text-indigo-300">
-                Testing Guide
-              </Link>
-            </h3>
-            <p className="text-gray-700 dark:text-gray-300">
-              Manual testing procedures, chat testing workflows, and quality assurance practices.
-            </p>
-          </div>
-        </div>
-      </div>
-      
-      <div className="mb-10">
-        <h2 className="text-2xl font-semibold mb-6 text-indigo-700 dark:text-indigo-400 flex items-center">
-          <Map className="h-5 w-5 mr-2" />
-          Project Information
-        </h2>
-        
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div className="p-4 border border-gray-200 rounded-lg shadow-sm dark:border-gray-700">
-            <h3 className="text-lg font-medium mb-3 text-indigo-700 dark:text-indigo-400 flex items-center">
-              <Map className="h-5 w-5 mr-2 text-indigo-600 dark:text-indigo-400" />
-              <Link href="/docs/roadmap" className="hover:text-indigo-800 dark:hover:text-indigo-300">
-                Development Roadmap
-              </Link>
-            </h3>
-            <p className="text-gray-700 dark:text-gray-300">
-              Completed features, upcoming releases, and long-term vision for the project.
-            </p>
-          </div>
-          
-          <div className="p-4 border border-gray-200 rounded-lg shadow-sm dark:border-gray-700">
-            <h3 className="text-lg font-medium mb-3 text-indigo-700 dark:text-indigo-400 flex items-center">
-              <Award className="h-5 w-5 mr-2 text-indigo-600 dark:text-indigo-400" />
-              <Link href="/docs/credits" className="hover:text-indigo-800 dark:hover:text-indigo-300">
-                Credits
-              </Link>
-            </h3>
-            <p className="text-gray-700 dark:text-gray-300">
-              Acknowledgments, contributors, and technology credits for the project.
-            </p>
-          </div>
-          
-          <div className="p-4 border border-gray-200 rounded-lg shadow-sm dark:border-gray-700">
-            <h3 className="text-lg font-medium mb-3 text-indigo-700 dark:text-indigo-400 flex items-center">
-              <FileJson className="h-5 w-5 mr-2 text-indigo-600 dark:text-indigo-400" />
-              <Link href="/docs/license" className="hover:text-indigo-800 dark:hover:text-indigo-300">
-                License Information
-              </Link>
-            </h3>
-            <p className="text-gray-700 dark:text-gray-300">
-              MIT License details, usage rights, and third-party library attributions.
-            </p>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/docs-navigation.tsx
+++ b/src/components/docs-navigation.tsx
@@ -12,9 +12,19 @@ export default function DocsNavigation({ className = '' }: DocsNavigationProps) 
   
   // Determine if we're on the docs home page
   const isDocsHome = pathname === '/docs';
+  const isDeveloperDocsHome = pathname === '/docs/developer';
   
   // Extract the current doc section, like "how-to-use" or "features"
   const currentSection = pathname.split('/').pop();
+  
+  // Check if we're on a developer docs page
+  const isDeveloperDocsPage = pathname.startsWith('/docs/dev-setup') || 
+                             pathname.startsWith('/docs/architecture') || 
+                             pathname.startsWith('/docs/api') || 
+                             pathname.startsWith('/docs/security') || 
+                             pathname.startsWith('/docs/contributing') || 
+                             pathname.startsWith('/docs/testing') ||
+                             pathname === '/docs/developer';
   
   return (
     <nav className={`flex items-center text-sm font-medium mb-6 ${className}`}>
@@ -29,6 +39,45 @@ export default function DocsNavigation({ className = '' }: DocsNavigationProps) 
       
       {isDocsHome ? (
         <span className="text-indigo-600 dark:text-indigo-400">Documentation</span>
+      ) : isDeveloperDocsHome ? (
+        <>
+          <Link 
+            href="/docs" 
+            className="text-gray-900 hover:text-indigo-600 dark:text-gray-200 dark:hover:text-indigo-400"
+          >
+            Documentation
+          </Link>
+          
+          <span className="mx-2 text-gray-500 dark:text-gray-400">/</span>
+          
+          <span className="text-indigo-600 dark:text-indigo-400">
+            Developer Docs
+          </span>
+        </>
+      ) : isDeveloperDocsPage ? (
+        <>
+          <Link 
+            href="/docs" 
+            className="text-gray-900 hover:text-indigo-600 dark:text-gray-200 dark:hover:text-indigo-400"
+          >
+            Documentation
+          </Link>
+          
+          <span className="mx-2 text-gray-500 dark:text-gray-400">/</span>
+          
+          <Link 
+            href="/docs/developer" 
+            className="text-gray-900 hover:text-indigo-600 dark:text-gray-200 dark:hover:text-indigo-400"
+          >
+            Developer Docs
+          </Link>
+          
+          <span className="mx-2 text-gray-500 dark:text-gray-400">/</span>
+          
+          <span className="text-indigo-600 dark:text-indigo-400">
+            {formatSectionName(currentSection || '')}
+          </span>
+        </>
       ) : (
         <>
           <Link 
@@ -51,6 +100,10 @@ export default function DocsNavigation({ className = '' }: DocsNavigationProps) 
 
 // Helper function to format section names for display
 function formatSectionName(section: string): string {
+  // Handle special cases for developer docs
+  if (section === 'dev-setup') return 'Development Setup';
+  if (section === 'api') return 'API Reference';
+  
   // Replace hyphens with spaces and capitalize each word
   return section
     .split('-')

--- a/src/components/edit-page/basic-info-section.tsx
+++ b/src/components/edit-page/basic-info-section.tsx
@@ -13,7 +13,8 @@ interface BasicInfoSectionProps {
   onGenreChange: (section: 'selected_traits' | 'added_traits', field: string, value: string) => void;
   currentGenre: string;
   subGenres: {value: string, label: string}[];
-  fieldLoadingStates: Record<string, boolean>;
+  isFieldRegenerating: (field: string, index?: number, subField?: string) => boolean;
+  regeneratingFields: Set<string>;
 }
 
 export const BasicInfoSection = ({
@@ -23,11 +24,31 @@ export const BasicInfoSection = ({
   onGenreChange,
   currentGenre,
   subGenres,
-  fieldLoadingStates
+  isFieldRegenerating,
+  regeneratingFields
 }: BasicInfoSectionProps) => {
+  
+  // Check if any basic info field is regenerating
+  const hasBasicInfoLoading = regeneratingFields.has('name') || 
+                              regeneratingFields.has('appearance') || 
+                              regeneratingFields.has('personality') || 
+                              regeneratingFields.has('backstory_hook');
+
   return (
     <FormSection title="Basic Information">
-      <div className="mb-4">
+      {/* Loading overlay when any field is regenerating */}
+      {hasBasicInfoLoading && (
+        <div className="mb-4 p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+          <div className="flex items-center gap-3">
+            <div className="animate-spin rounded-full h-5 w-5 border-2 border-blue-200 border-t-blue-600 dark:border-blue-700 dark:border-t-blue-300"></div>
+            <p className="text-sm font-medium text-blue-800 dark:text-blue-200">
+              Regenerating character information...
+            </p>
+          </div>
+        </div>
+      )}
+
+      <div className={`mb-4 ${isFieldRegenerating('name') ? 'bg-blue-50 dark:bg-blue-900/20 rounded-lg p-3 border border-blue-200 dark:border-blue-800' : ''}`}>
         <label className="block text-sm font-medium mb-1">
           Name
         </label>
@@ -37,11 +58,12 @@ export const BasicInfoSection = ({
             value={character.name}
             onChange={(e) => onInputChange('name', e.target.value)}
             className="flex-grow p-2 border border-theme rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-secondary"
+            disabled={isFieldRegenerating('name')}
           />
           <RegenerateButton
             field="name"
             onClick={(e) => onRegenerateField('name', e)}
-            isLoading={fieldLoadingStates['name'] || false}
+            isLoading={isFieldRegenerating('name')}
           />
         </div>
       </div>
@@ -68,7 +90,7 @@ export const BasicInfoSection = ({
         />
       </div>
       
-      <div className="mb-4">
+      <div className={`mb-4 ${isFieldRegenerating('appearance') ? 'bg-blue-50 dark:bg-blue-900/20 rounded-lg p-3 border border-blue-200 dark:border-blue-800' : ''}`}>
         <label className="block text-sm font-medium mb-1">
           Appearance
         </label>
@@ -78,16 +100,17 @@ export const BasicInfoSection = ({
             onChange={(e) => onInputChange('appearance', e.target.value)}
             rows={4}
             className="flex-grow p-2 border border-theme rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-secondary"
+            disabled={isFieldRegenerating('appearance')}
           />
           <RegenerateButton
             field="appearance"
             onClick={(e) => onRegenerateField('appearance', e)}
-            isLoading={fieldLoadingStates['appearance'] || false}
+            isLoading={isFieldRegenerating('appearance')}
           />
         </div>
       </div>
       
-      <div className="mb-4">
+      <div className={`mb-4 ${isFieldRegenerating('personality') ? 'bg-blue-50 dark:bg-blue-900/20 rounded-lg p-3 border border-blue-200 dark:border-blue-800' : ''}`}>
         <label className="block text-sm font-medium mb-1">
           Personality
         </label>
@@ -97,16 +120,17 @@ export const BasicInfoSection = ({
             onChange={(e) => onInputChange('personality', e.target.value)}
             rows={4}
             className="flex-grow p-2 border border-theme rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-secondary"
+            disabled={isFieldRegenerating('personality')}
           />
           <RegenerateButton
             field="personality"
             onClick={(e) => onRegenerateField('personality', e)}
-            isLoading={fieldLoadingStates['personality'] || false}
+            isLoading={isFieldRegenerating('personality')}
           />
         </div>
       </div>
       
-      <div className="mb-4">
+      <div className={`mb-4 ${isFieldRegenerating('backstory_hook') ? 'bg-blue-50 dark:bg-blue-900/20 rounded-lg p-3 border border-blue-200 dark:border-blue-800' : ''}`}>
         <label className="block text-sm font-medium mb-1">
           Backstory Hook
         </label>
@@ -116,11 +140,12 @@ export const BasicInfoSection = ({
             onChange={(e) => onInputChange('backstory_hook', e.target.value)}
             rows={2}
             className="flex-grow p-2 border border-theme rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-secondary"
+            disabled={isFieldRegenerating('backstory_hook')}
           />
           <RegenerateButton
             field="backstory_hook"
             onClick={(e) => onRegenerateField('backstory_hook', e)}
-            isLoading={fieldLoadingStates['backstory_hook'] || false}
+            isLoading={isFieldRegenerating('backstory_hook')}
           />
         </div>
       </div>

--- a/src/components/edit-page/dialogue-section.tsx
+++ b/src/components/edit-page/dialogue-section.tsx
@@ -10,16 +10,23 @@ interface DialogueSectionProps {
   character: Character;
   onArrayInputChange: <T extends unknown>(field: keyof Character, value: T[]) => void;
   onRegenerateField: (field: string, e: React.MouseEvent<HTMLButtonElement>) => void;
-  fieldLoadingStates: Record<string, boolean>;
+  isFieldRegenerating: (field: string, index?: number, subField?: string) => boolean;
+  regeneratingFields: Set<string>;
 }
 
 export const DialogueSection = ({
   character,
   onArrayInputChange,
   onRegenerateField,
-  fieldLoadingStates
+  isFieldRegenerating,
+  regeneratingFields
 }: DialogueSectionProps) => {
   
+  // Check if any dialogue field is loading
+  const hasDialogueLoading = Array.from(regeneratingFields).some(field => 
+    field.startsWith('dialogue_')
+  );
+
   // Add new dialogue
   const handleAddDialogue = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
@@ -46,6 +53,18 @@ export const DialogueSection = ({
   
   return (
     <FormSection title="Dialogue Lines">
+      {/* Loading overlay when any dialogue is regenerating */}
+      {hasDialogueLoading && (
+        <div className="mb-4 p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+          <div className="flex items-center gap-3">
+            <div className="animate-spin rounded-full h-5 w-5 border-2 border-blue-200 border-t-blue-600 dark:border-blue-700 dark:border-t-blue-300"></div>
+            <p className="text-sm font-medium text-blue-800 dark:text-blue-200">
+              Regenerating dialogue lines...
+            </p>
+          </div>
+        </div>
+      )}
+
       <div className="flex justify-between items-center mb-4">
         <Button 
           variant="secondary" 
@@ -59,33 +78,43 @@ export const DialogueSection = ({
       
       {character.dialogue_lines && character.dialogue_lines.length > 0 ? (
         <div className="space-y-3">
-          {character.dialogue_lines.map((line, index) => (
-            <div key={index} className="mb-2 flex">
-              <input
-                type="text"
-                value={line}
-                onChange={(e) => {
-                  const newLines = [...character.dialogue_lines!];
-                  newLines[index] = e.target.value;
-                  onArrayInputChange('dialogue_lines', newLines);
-                }}
-                className="flex-grow p-2 border border-theme rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-secondary"
-              />
-              <RegenerateButton
-                field={`dialogue_${index}`}
-                onClick={(e) => onRegenerateField(`dialogue_${index}`, e)}
-                isLoading={fieldLoadingStates[`dialogue_${index}`] || false}
-              />
-              <button
-                type="button"
-                onClick={handleRemoveDialogue(index)}
-                className="ml-2 p-2 text-red-600 hover:text-red-800 bg-red-50 rounded-md dark:bg-red-900/20 dark:text-red-400 dark:hover:text-red-300"
-                title="Remove Dialogue"
+          {character.dialogue_lines.map((line, index) => {
+            const isDialogueLoading = isFieldRegenerating('dialogue', index);
+            
+            return (
+              <div 
+                key={index} 
+                className={`mb-2 flex ${
+                  isDialogueLoading ? 'bg-blue-50 dark:bg-blue-900/20 rounded-lg p-3 border border-blue-200 dark:border-blue-800' : ''
+                }`}
               >
-                <Trash2 className="h-5 w-5" />
-              </button>
-            </div>
-          ))}
+                <input
+                  type="text"
+                  value={line}
+                  onChange={(e) => {
+                    const newLines = [...character.dialogue_lines!];
+                    newLines[index] = e.target.value;
+                    onArrayInputChange('dialogue_lines', newLines);
+                  }}
+                  className="flex-grow p-2 border border-theme rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-secondary"
+                  disabled={isDialogueLoading}
+                />
+                <RegenerateButton
+                  field={`dialogue_${index}`}
+                  onClick={(e) => onRegenerateField(`dialogue_${index}`, e)}
+                  isLoading={isDialogueLoading}
+                />
+                <button
+                  type="button"
+                  onClick={handleRemoveDialogue(index)}
+                  className="ml-2 p-2 text-red-600 hover:text-red-800 bg-red-50 rounded-md dark:bg-red-900/20 dark:text-red-400 dark:hover:text-red-300"
+                  title="Remove Dialogue"
+                >
+                  <Trash2 className="h-5 w-5" />
+                </button>
+              </div>
+            );
+          })}
         </div>
       ) : (
         <div className="text-center py-8 bg-secondary rounded-lg border border-dashed border-theme">

--- a/src/components/edit-page/items-section.tsx
+++ b/src/components/edit-page/items-section.tsx
@@ -10,16 +10,23 @@ interface ItemsSectionProps {
   character: Character;
   onArrayInputChange: <T extends unknown>(field: keyof Character, value: T[]) => void;
   onRegenerateField: (field: string, e: React.MouseEvent<HTMLButtonElement>) => void;
-  fieldLoadingStates: Record<string, boolean>;
+  isFieldRegenerating: (field: string, index?: number, subField?: string) => boolean;
+  regeneratingFields: Set<string>;
 }
 
 export const ItemsSection = ({
   character,
   onArrayInputChange,
   onRegenerateField,
-  fieldLoadingStates
+  isFieldRegenerating,
+  regeneratingFields
 }: ItemsSectionProps) => {
   
+  // Check if any item field is loading
+  const hasItemLoading = Array.from(regeneratingFields).some(field => 
+    field.startsWith('item_')
+  );
+
   // Add a new item
   const handleAddItem = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
@@ -46,6 +53,18 @@ export const ItemsSection = ({
   
   return (
     <FormSection title="Items">
+      {/* Loading overlay when any item is regenerating */}
+      {hasItemLoading && (
+        <div className="mb-4 p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+          <div className="flex items-center gap-3">
+            <div className="animate-spin rounded-full h-5 w-5 border-2 border-blue-200 border-t-blue-600 dark:border-blue-700 dark:border-t-blue-300"></div>
+            <p className="text-sm font-medium text-blue-800 dark:text-blue-200">
+              Regenerating items...
+            </p>
+          </div>
+        </div>
+      )}
+
       <div className="flex justify-between items-center mb-4">
         <Button 
           variant="secondary" 
@@ -59,33 +78,43 @@ export const ItemsSection = ({
       
       {character.items && character.items.length > 0 ? (
         <div className="space-y-3">
-          {character.items.map((item, index) => (
-            <div key={index} className="mb-2 flex">
-              <input
-                type="text"
-                value={item}
-                onChange={(e) => {
-                  const newItems = [...character.items!];
-                  newItems[index] = e.target.value;
-                  onArrayInputChange('items', newItems);
-                }}
-                className="flex-grow p-2 border border-theme rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-secondary"
-              />
-              <RegenerateButton
-                field={`item_${index}`}
-                onClick={(e) => onRegenerateField(`item_${index}`, e)}
-                isLoading={fieldLoadingStates[`item_${index}`] || false}
-              />
-              <button
-                type="button"
-                onClick={handleRemoveItem(index)}
-                className="ml-2 p-2 text-red-600 hover:text-red-800 bg-red-50 rounded-md dark:bg-red-900/20 dark:text-red-400 dark:hover:text-red-300"
-                title="Remove Item"
+          {character.items.map((item, index) => {
+            const isItemLoading = isFieldRegenerating('item', index);
+            
+            return (
+              <div 
+                key={index} 
+                className={`mb-2 flex ${
+                  isItemLoading ? 'bg-blue-50 dark:bg-blue-900/20 rounded-lg p-3 border border-blue-200 dark:border-blue-800' : ''
+                }`}
               >
-                <Trash2 className="h-5 w-5" />
-              </button>
-            </div>
-          ))}
+                <input
+                  type="text"
+                  value={item}
+                  onChange={(e) => {
+                    const newItems = [...character.items!];
+                    newItems[index] = e.target.value;
+                    onArrayInputChange('items', newItems);
+                  }}
+                  className="flex-grow p-2 border border-theme rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-secondary"
+                  disabled={isItemLoading}
+                />
+                <RegenerateButton
+                  field={`item_${index}`}
+                  onClick={(e) => onRegenerateField(`item_${index}`, e)}
+                  isLoading={isItemLoading}
+                />
+                <button
+                  type="button"
+                  onClick={handleRemoveItem(index)}
+                  className="ml-2 p-2 text-red-600 hover:text-red-800 bg-red-50 rounded-md dark:bg-red-900/20 dark:text-red-400 dark:hover:text-red-300"
+                  title="Remove Item"
+                >
+                  <Trash2 className="h-5 w-5" />
+                </button>
+              </div>
+            );
+          })}
         </div>
       ) : (
         <div className="text-center py-8 bg-secondary rounded-lg border border-dashed border-theme">

--- a/src/components/edit-page/portrait-section.tsx
+++ b/src/components/edit-page/portrait-section.tsx
@@ -1,4 +1,3 @@
-// src/components/edit-page/portrait-section.tsx
 'use client';
 
 import React, { useState } from 'react';
@@ -25,7 +24,6 @@ interface PortraitSectionProps {
 }
 
 // Models that support image editing (according to OpenAI API docs)
-// Note: DALL-E 2 editing is unreliable despite meeting all documented requirements
 const EDIT_SUPPORTED_MODELS: ImageModel[] = ['gpt-image-1'];
 
 export function PortraitSection({
@@ -82,7 +80,10 @@ export function PortraitSection({
 
     // Check if selected model supports editing
     if (!EDIT_SUPPORTED_MODELS.includes(selectedImageModel)) {
-      setEditError(`${selectedImageModel} doesn't support image editing. Please switch to dall-e-2 or gpt-image-1.`);
+      const modelName = selectedImageModel === 'dall-e-2' ? 'DALL-E 2' : 
+                       selectedImageModel === 'dall-e-3' ? 'DALL-E 3' : 
+                       selectedImageModel;
+      setEditError(`${modelName} doesn't support image editing. Please switch to gpt-image-1.`);
       return;
     }
     
@@ -121,7 +122,10 @@ export function PortraitSection({
           } else if (errorData.errorType === 'timeout') {
             errorMessage = 'Portrait editing timed out. Please try again.';
           } else if (errorData.errorType === 'unsupported_model') {
-            errorMessage = `${selectedImageModel} doesn't support editing. Switch to dall-e-2 or gpt-image-1.`;
+            const modelName = selectedImageModel === 'dall-e-2' ? 'DALL-E 2' : 
+                             selectedImageModel === 'dall-e-3' ? 'DALL-E 3' : 
+                             selectedImageModel;
+            errorMessage = `${modelName} doesn't support editing. Switch to gpt-image-1.`;
           }
         } catch (parseError) {
           console.error("Failed to parse error response:", parseError);
@@ -202,6 +206,18 @@ export function PortraitSection({
   return (
     <FormSection title="Character Portrait">
       <div className="space-y-4">
+        {/* Loading overlay when portrait is regenerating or being edited */}
+        {(isRegeneratingPortrait || isEditingPortrait) && (
+          <div className="mb-4 p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+            <div className="flex items-center gap-3">
+              <div className="animate-spin rounded-full h-5 w-5 border-2 border-blue-200 border-t-blue-600 dark:border-blue-700 dark:border-t-blue-300"></div>
+              <p className="text-sm font-medium text-blue-800 dark:text-blue-200">
+                {isRegeneratingPortrait ? 'Generating new portrait...' : 'Editing portrait with OpenAI...'}
+              </p>
+            </div>
+          </div>
+        )}
+        
         {/* Unsaved changes warning - more compact */}
         {hasUnsavedChanges && (
           <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3">
@@ -224,7 +240,7 @@ export function PortraitSection({
                   Portrait Editing Not Available
                 </p>
                 <p className="text-sm text-blue-700 dark:text-blue-300">
-                  <strong>{selectedImageModel}</strong> doesn't support reliable image editing. Switch to <strong>gpt-image-1</strong> above to enable portrait editing.
+                  <strong>{selectedImageModel === 'dall-e-2' ? 'DALL-E 2' : selectedImageModel === 'dall-e-3' ? 'DALL-E 3' : selectedImageModel}</strong> doesn't support reliable image editing. Switch to <strong>gpt-image-1</strong> above to enable portrait editing.
                 </p>
               </div>
             </div>
@@ -256,7 +272,7 @@ export function PortraitSection({
                   Edit Portrait with OpenAI
                 </label>
                 <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
-                  Uses OpenAI's image editing API to modify your existing portrait. Only works with dall-e-2 and gpt-image-1.
+                  Uses OpenAI's image editing API to modify your existing portrait. Only works with gpt-image-1.
                 </p>
                 <textarea
                   id="edit-prompt"
@@ -301,7 +317,7 @@ export function PortraitSection({
 
               {!editSupported && (
                 <p className="text-sm text-gray-500 dark:text-gray-400 text-center">
-                  Switch to dall-e-2 or gpt-image-1 to enable editing
+                  Switch to gpt-image-1 to enable editing
                 </p>
               )}
             </div>
@@ -338,7 +354,7 @@ export function PortraitSection({
                     onClick={handleToggleEditPrompt}
                     disabled={isRegeneratingPortrait || isEditingPortrait || !editSupported}
                     type="button"
-                    title={!editSupported ? `${selectedImageModel} doesn't support editing. Use dall-e-2 or gpt-image-1.` : 'Edit existing portrait'}
+                    title={!editSupported ? `${selectedImageModel === 'dall-e-2' ? 'DALL-E 2' : selectedImageModel === 'dall-e-3' ? 'DALL-E 3' : selectedImageModel} doesn't support editing. Use gpt-image-1.` : 'Edit existing portrait'}
                   >
                     <Edit3 className="h-4 w-4 mr-2" />
                     Edit Portrait
@@ -360,18 +376,6 @@ export function PortraitSection({
         </div>
         
         {/* Status Messages */}
-        {/* Generation Status */}
-        {(isRegeneratingPortrait || isEditingPortrait) && (
-          <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-3">
-            <div className="flex items-center gap-2">
-              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600 dark:border-blue-400"></div>
-              <p className="text-sm font-medium text-blue-800 dark:text-blue-200">
-                {isRegeneratingPortrait ? 'Generating new portrait...' : 'Editing portrait with OpenAI...'}
-              </p>
-            </div>
-          </div>
-        )}
-
         {/* Edit Error Display */}
         {editError && (
           <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3">

--- a/src/components/edit-page/quests-section.tsx
+++ b/src/components/edit-page/quests-section.tsx
@@ -10,17 +10,24 @@ interface QuestsSectionProps {
   character: Character;
   onArrayInputChange: <T extends unknown>(field: keyof Character, value: T[]) => void;
   onRegenerateField: (field: string, e: React.MouseEvent<HTMLButtonElement>) => void;
-  fieldLoadingStates: Record<string, boolean>;
+  isFieldRegenerating: (field: string, index?: number, subField?: string) => boolean;
+  regeneratingFields: Set<string>;
 }
 
 export const QuestsSection = ({
   character,
   onArrayInputChange,
   onRegenerateField,
-  fieldLoadingStates
+  isFieldRegenerating,
+  regeneratingFields
 }: QuestsSectionProps) => {
   
-  // Add a new quest
+  // Check if any quest-related field is loading
+  const hasQuestLoading = Array.from(regeneratingFields).some(field => 
+    field.startsWith('quest_')
+  );
+
+  // Add new quest
   const handleAddQuest = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     e.stopPropagation();
@@ -52,6 +59,18 @@ export const QuestsSection = ({
   
   return (
     <FormSection title="Quests">
+      {/* Loading overlay when any quest is regenerating */}
+      {hasQuestLoading && (
+        <div className="mb-4 p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+          <div className="flex items-center gap-3">
+            <div className="animate-spin rounded-full h-5 w-5 border-2 border-blue-200 border-t-blue-600 dark:border-blue-700 dark:border-t-blue-300"></div>
+            <p className="text-sm font-medium text-blue-800 dark:text-blue-200">
+              Regenerating quest content...
+            </p>
+          </div>
+        </div>
+      )}
+
       <div className="flex justify-between items-center mb-4">
         <Button 
           variant="secondary" 
@@ -65,118 +84,133 @@ export const QuestsSection = ({
       
       {character.quests && character.quests.length > 0 ? (
         <div className="space-y-6">
-          {character.quests.map((quest, index) => (
-            <div key={index} className="mb-6 pb-6 border-b border-theme last:border-0 last:mb-0 last:pb-0 bg-secondary p-4 rounded-lg">
-              <div className="flex justify-between items-center mb-2">
-                <h3 className="text-lg font-semibold">Quest #{index + 1}</h3>
-                <button
-                  type="button"
-                  onClick={handleRemoveQuest(index)}
-                  className="p-2 text-red-600 hover:text-red-800 bg-red-50 rounded-md dark:bg-red-900/20 dark:text-red-400 dark:hover:text-red-300"
-                  title="Remove Quest"
-                >
-                  <Trash2 className="h-5 w-5" />
-                </button>
-              </div>
+          {character.quests.map((quest, index) => {
+            const isQuestLoading = isFieldRegenerating('quest', index, 'whole');
+            const isTitleLoading = isFieldRegenerating('quest', index, 'title');
+            const isDescriptionLoading = isFieldRegenerating('quest', index, 'description');
+            const isRewardLoading = isFieldRegenerating('quest', index, 'reward');
             
-              <div className="mb-2">
-                <label className="block text-sm font-medium mb-1">
-                  Quest Title
-                </label>
-                <div className="flex">
-                  <input
-                    type="text"
-                    value={quest.title}
-                    onChange={(e) => {
-                      const newQuests = [...character.quests!];
-                      newQuests[index] = {...newQuests[index], title: e.target.value};
-                      onArrayInputChange('quests', newQuests);
-                    }}
-                    className="flex-grow p-2 border border-theme rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-secondary"
-                  />
-                  <RegenerateButton
-                    field={`quest_${index}_title`}
-                    onClick={(e) => onRegenerateField(`quest_${index}_title`, e)}
-                    isLoading={fieldLoadingStates[`quest_${index}_title`] || false}
-                  />
+            return (
+              <div 
+                key={index} 
+                className={`mb-6 pb-6 border-b border-theme last:border-0 last:mb-0 last:pb-0 bg-secondary p-4 rounded-lg ${
+                  isQuestLoading ? 'bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800' : ''
+                }`}
+              >
+                <div className="flex justify-between items-center mb-2">
+                  <h3 className="text-lg font-semibold">Quest #{index + 1}</h3>
+                  <button
+                    type="button"
+                    onClick={handleRemoveQuest(index)}
+                    className="p-2 text-red-600 hover:text-red-800 bg-red-50 rounded-md dark:bg-red-900/20 dark:text-red-400 dark:hover:text-red-300"
+                    title="Remove Quest"
+                  >
+                    <Trash2 className="h-5 w-5" />
+                  </button>
                 </div>
-              </div>
               
-              <div className="mb-2">
-                <label className="block text-sm font-medium mb-1">
-                  Quest Description
-                </label>
-                <div className="flex">
-                  <textarea
-                    value={quest.description}
-                    onChange={(e) => {
-                      const newQuests = [...character.quests!];
-                      newQuests[index] = {...newQuests[index], description: e.target.value};
-                      onArrayInputChange('quests', newQuests);
-                    }}
-                    rows={3}
-                    className="flex-grow p-2 border border-theme rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-secondary"
-                  />
-                  <RegenerateButton
-                    field={`quest_${index}_description`}
-                    onClick={(e) => onRegenerateField(`quest_${index}_description`, e)}
-                    isLoading={fieldLoadingStates[`quest_${index}_description`] || false}
-                  />
+                <div className={`mb-2 ${isTitleLoading ? 'bg-blue-50 dark:bg-blue-900/20 rounded p-2 border border-blue-200 dark:border-blue-800' : ''}`}>
+                  <label className="block text-sm font-medium mb-1">
+                    Quest Title
+                  </label>
+                  <div className="flex">
+                    <input
+                      type="text"
+                      value={quest.title}
+                      onChange={(e) => {
+                        const newQuests = [...character.quests!];
+                        newQuests[index] = {...newQuests[index], title: e.target.value};
+                        onArrayInputChange('quests', newQuests);
+                      }}
+                      className="flex-grow p-2 border border-theme rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-secondary"
+                      disabled={isTitleLoading}
+                    />
+                    <RegenerateButton
+                      field={`quest_${index}_title`}
+                      onClick={(e) => onRegenerateField(`quest_${index}_title`, e)}
+                      isLoading={isTitleLoading}
+                    />
+                  </div>
                 </div>
-              </div>
-              
-              <div className="mb-2">
-                <label className="block text-sm font-medium mb-1">
-                  Quest Reward
-                </label>
-                <div className="flex">
-                  <input
-                    type="text"
-                    value={quest.reward}
-                    onChange={(e) => {
-                      const newQuests = [...character.quests!];
-                      newQuests[index] = {...newQuests[index], reward: e.target.value};
-                      onArrayInputChange('quests', newQuests);
-                    }}
-                    className="flex-grow p-2 border border-theme rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-secondary"
-                  />
-                  <RegenerateButton
-                    field={`quest_${index}_reward`}
-                    onClick={(e) => onRegenerateField(`quest_${index}_reward`, e)}
-                    isLoading={fieldLoadingStates[`quest_${index}_reward`] || false}
-                  />
+                
+                <div className={`mb-2 ${isDescriptionLoading ? 'bg-blue-50 dark:bg-blue-900/20 rounded p-2 border border-blue-200 dark:border-blue-800' : ''}`}>
+                  <label className="block text-sm font-medium mb-1">
+                    Quest Description
+                  </label>
+                  <div className="flex">
+                    <textarea
+                      value={quest.description}
+                      onChange={(e) => {
+                        const newQuests = [...character.quests!];
+                        newQuests[index] = {...newQuests[index], description: e.target.value};
+                        onArrayInputChange('quests', newQuests);
+                      }}
+                      rows={3}
+                      className="flex-grow p-2 border border-theme rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-secondary"
+                      disabled={isDescriptionLoading}
+                    />
+                    <RegenerateButton
+                      field={`quest_${index}_description`}
+                      onClick={(e) => onRegenerateField(`quest_${index}_description`, e)}
+                      isLoading={isDescriptionLoading}
+                    />
+                  </div>
                 </div>
-              </div>
+                
+                <div className={`mb-2 ${isRewardLoading ? 'bg-blue-50 dark:bg-blue-900/20 rounded p-2 border border-blue-200 dark:border-blue-800' : ''}`}>
+                  <label className="block text-sm font-medium mb-1">
+                    Quest Reward
+                  </label>
+                  <div className="flex">
+                    <input
+                      type="text"
+                      value={quest.reward}
+                      onChange={(e) => {
+                        const newQuests = [...character.quests!];
+                        newQuests[index] = {...newQuests[index], reward: e.target.value};
+                        onArrayInputChange('quests', newQuests);
+                      }}
+                      className="flex-grow p-2 border border-theme rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 bg-secondary"
+                      disabled={isRewardLoading}
+                    />
+                    <RegenerateButton
+                      field={`quest_${index}_reward`}
+                      onClick={(e) => onRegenerateField(`quest_${index}_reward`, e)}
+                      isLoading={isRewardLoading}
+                    />
+                  </div>
+                </div>
 
-              <div className="mt-2">
-                <button
-                  type="button"
-                  onClick={(e) => onRegenerateField(`quest_${index}_whole`, e)}
-                  className={`
-                    w-full p-2 rounded-md flex items-center justify-center
-                    ${fieldLoadingStates[`quest_${index}_whole`] 
-                      ? 'bg-gray-100 text-gray-400 dark:bg-gray-800 dark:text-gray-500' 
-                      : 'text-indigo-600 hover:text-indigo-800 bg-indigo-50 dark:bg-indigo-900/20 dark:text-indigo-400 dark:hover:text-indigo-300'
-                    }
-                  `}
-                  disabled={fieldLoadingStates[`quest_${index}_whole`] || false}
-                  title="Regenerate Entire Quest"
-                >
-                  {fieldLoadingStates[`quest_${index}_whole`] ? (
-                    <>
-                      <div className="h-5 w-5 animate-spin rounded-full border-2 border-indigo-200 border-t-indigo-600 dark:border-indigo-700 dark:border-t-indigo-300 mr-2"></div>
-                      Regenerating...
-                    </>
-                  ) : (
-                    <>
-                      <RefreshCw className="h-5 w-5 mr-2" />
-                      Regenerate Entire Quest
-                    </>
-                  )}
-                </button>
+                <div className="mt-2">
+                  <button
+                    type="button"
+                    onClick={(e) => onRegenerateField(`quest_${index}_whole`, e)}
+                    className={`
+                      w-full p-2 rounded-md flex items-center justify-center transition-all duration-200
+                      ${isQuestLoading 
+                        ? 'bg-blue-50 text-blue-600 dark:bg-blue-900/20 dark:text-blue-400 border border-blue-200 dark:border-blue-700 cursor-not-allowed' 
+                        : 'text-indigo-600 hover:text-indigo-800 bg-indigo-50 dark:bg-indigo-900/20 dark:text-indigo-400 dark:hover:text-indigo-300 hover:bg-indigo-100 dark:hover:bg-indigo-900/30'
+                      }
+                    `}
+                    disabled={isQuestLoading}
+                    title="Regenerate Entire Quest"
+                  >
+                    {isQuestLoading ? (
+                      <>
+                        <div className="h-5 w-5 animate-spin rounded-full border-2 border-blue-200 border-t-blue-600 dark:border-blue-700 dark:border-t-blue-300 mr-2"></div>
+                        Regenerating...
+                      </>
+                    ) : (
+                      <>
+                        <RefreshCw className="h-5 w-5 mr-2" />
+                        Regenerate Entire Quest
+                      </>
+                    )}
+                  </button>
+                </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       ) : (
         <div className="text-center py-8 bg-secondary rounded-lg border border-dashed border-theme">

--- a/src/components/edit-page/shared.tsx
+++ b/src/components/edit-page/shared.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { Sparkles, CheckCircle, AlertCircle } from 'lucide-react';
+import { RotateCcw, CheckCircle, AlertCircle } from 'lucide-react';
 
 // Feedback Message Component for showing success/error messages
 export const FeedbackMessage = ({ message }: { message: {type: 'success' | 'error', text: string} | null }) => {
@@ -41,17 +41,19 @@ export const RegenerateButton = ({
       onClick={onClick}
       disabled={isLoading}
       className={`
-        ml-2 p-2 rounded-md transition-colors
+        ml-2 p-2 rounded-md transition-all duration-200 relative
         ${isLoading 
-          ? 'bg-gray-100 text-gray-400 dark:bg-gray-800 dark:text-gray-500' 
-          : 'text-indigo-600 hover:text-indigo-800 bg-indigo-50 dark:bg-indigo-900/20 dark:text-indigo-400 dark:hover:text-indigo-300'}
+          ? 'bg-blue-50 text-blue-600 dark:bg-blue-900/20 dark:text-blue-400 cursor-not-allowed border border-blue-200 dark:border-blue-700' 
+          : 'text-indigo-600 hover:text-indigo-800 bg-indigo-50 dark:bg-indigo-900/20 dark:text-indigo-400 dark:hover:text-indigo-300 hover:bg-indigo-100 dark:hover:bg-indigo-900/30'}
       `}
       title={isLoading ? "Regenerating..." : "Regenerate with AI"}
     >
       {isLoading ? (
-        <div className="h-5 w-5 animate-spin rounded-full border-2 border-indigo-200 border-t-indigo-600 dark:border-indigo-700 dark:border-t-indigo-300"></div>
+        <div className="flex items-center justify-center">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-blue-200 border-t-blue-600 dark:border-blue-700 dark:border-t-blue-300"></div>
+        </div>
       ) : (
-        <Sparkles className="h-5 w-5" />
+        <RotateCcw className="h-5 w-5" />
       )}
     </button>
   );

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -24,7 +24,8 @@ import {
   Sparkles,
   Library,
   Server,
-  Database
+  Database,
+  MessageCircle
 } from 'lucide-react';
 import { ReactNode } from 'react';
 import { isValidElement } from 'react';
@@ -55,6 +56,7 @@ const navigationItems: NavItemType[] = [
     icon: <BookOpen className="h-5 w-5" />,
     items: [
       { title: 'How to Use', path: '/docs/how-to-use', icon: <File className="h-4 w-4" /> },
+      { title: 'Chat with Characters', path: '/docs/chat', icon: <MessageCircle className="h-4 w-4" /> },
       { title: 'Character Examples', path: '/docs/character-examples', icon: <File className="h-4 w-4" /> },
       { title: 'Generation Options', path: '/docs/generation-options', icon: <Settings className="h-4 w-4" /> },
       { title: 'Features', path: '/docs/features', icon: <List className="h-4 w-4" /> },
@@ -63,6 +65,7 @@ const navigationItems: NavItemType[] = [
       { title: 'FAQ', path: '/docs/faq', icon: <HelpCircle className="h-4 w-4" /> },
       { 
         title: 'Developer Docs', 
+        path: '/docs/developer',
         icon: <Terminal className="h-4 w-4" />,
         items: [
           { title: 'Dev Setup', path: '/docs/dev-setup', icon: <Code className="h-3 w-3" /> },
@@ -272,15 +275,35 @@ const NavItemWithState = ({ item, depth = 0, isFullSidebar, toggleSidebar }: Nav
   
   // For the Documentation section, only auto-expand if we're on a specific docs page
   // (not the main /docs page), otherwise start closed
+  // For Developer Docs, auto-expand if we're on any developer docs page
   const shouldStartOpen = () => {
     if (item.title === 'Documentation') {
       // Only auto-expand if we're on a specific docs page, not the main docs page
       return pathname !== '/docs' && pathname?.startsWith('/docs');
     }
+    if (item.title === 'Developer Docs') {
+      // Auto-expand if we're on any developer docs page (including the main developer page)
+      return pathname === '/docs/developer' || 
+             pathname?.startsWith('/docs/dev-setup') ||
+             pathname?.startsWith('/docs/architecture') ||
+             pathname?.startsWith('/docs/api') ||
+             pathname?.startsWith('/docs/security') ||
+             pathname?.startsWith('/docs/contributing') ||
+             pathname?.startsWith('/docs/testing') ||
+             pathname?.startsWith('/docs/deployment') ||
+             pathname?.startsWith('/docs/roadmap') ||
+             pathname?.startsWith('/docs/credits') ||
+             pathname?.startsWith('/docs/license');
+    }
     return isInPath(item);
   };
   
   const [isOpen, setIsOpen] = useState(shouldStartOpen());
+  
+  // Update the open state when pathname changes
+  useEffect(() => {
+    setIsOpen(shouldStartOpen());
+  }, [pathname]);
   
   return (
     <NavItem 

--- a/src/components/wizard-steps/results-step.tsx
+++ b/src/components/wizard-steps/results-step.tsx
@@ -124,6 +124,7 @@ export default function ResultsStep({ onNext, isGenerating }: ResultsStepProps) 
   const [isSaving, setIsSaving] = useState(false);
   const [showSuccessToast, setShowSuccessToast] = useState(false);
   const [successMessage, setSuccessMessage] = useState('');
+  const [hasBeenSavedToLibrary, setHasBeenSavedToLibrary] = useState(false);
 
   const handleSaveToLibrary = async (e?: React.MouseEvent) => {
     // Explicitly prevent any default behavior or event propagation
@@ -148,6 +149,9 @@ export default function ResultsStep({ onNext, isGenerating }: ResultsStepProps) 
       
       if (success) {
         console.log('Save successful - showing toast, NO REDIRECT');
+        
+        // Mark as saved to library
+        setHasBeenSavedToLibrary(true);
         
         // Explicitly check that we're still on the same page
         console.log('Current location after save:', window.location.pathname);
@@ -286,16 +290,29 @@ export default function ResultsStep({ onNext, isGenerating }: ResultsStepProps) 
           
           {/* Action Buttons */}
           <div className="flex flex-wrap gap-2">
-            <Button
-              variant="primary"
-              onClick={handleSaveToLibrary}
-              leftIcon={<Save className="h-4 w-4" />}
-              isLoading={isSaving}
-              size="sm"
-              type="button"
-            >
-              {isSaving ? 'Saving...' : 'Save to Library'}
-            </Button>
+            {/* Conditional Save to Library / View Library Button */}
+            {!hasBeenSavedToLibrary ? (
+              <Button
+                variant="primary"
+                onClick={handleSaveToLibrary}
+                leftIcon={<Save className="h-4 w-4" />}
+                isLoading={isSaving}
+                size="sm"
+                type="button"
+              >
+                {isSaving ? 'Saving...' : 'Save to Library'}
+              </Button>
+            ) : (
+              <Button
+                variant="primary"
+                onClick={handleViewLibrary}
+                leftIcon={<Library className="h-4 w-4" />}
+                size="sm"
+                type="button"
+              >
+                View Library
+              </Button>
+            )}
             
             <Button
               variant="secondary"
@@ -327,16 +344,6 @@ export default function ResultsStep({ onNext, isGenerating }: ResultsStepProps) 
                 Portrait
               </Button>
             )}
-            
-            {/* Button to view library - but doesn't auto-redirect */}
-            <Button
-              variant="secondary"
-              onClick={handleViewLibrary}
-              leftIcon={<Library className="h-4 w-4" />}
-              size="sm"
-            >
-              View Library
-            </Button>
           </div>
 
           {/* Portrait - Only show if there's image data or URL */}


### PR DESCRIPTION
# Improve Documentation Structure and Trait Editing UX

## Summary
This PR introduces a developer documentation homepage, improves sidebar navigation, and refines the trait editing experience across the edit page. It also adds consistent regeneration indicators and resolves issues with quest regeneration fallback logic.

## Changes

### 📚 Documentation & Navigation
- Added dedicated Developer Documentation homepage at `/docs/developer`
- Updated sidebar:
  - "Developer Docs" is now a clickable link and expands properly
  - Added "Chat with Characters" link under Documentation
  - Improved route matching for active highlighting
- Main Docs homepage now links to Developer Docs homepage
- Improved breadcrumbs for developer docs pages (e.g. `/docs/developer/testing`)

### 🧠 Trait Editing Improvements
- Additional Traits section now:
  - Capitalizes category names
  - Includes all unclassified traits (e.g. custom personality traits)
- Regenerate button icon changed to use `RotateCcw` consistently across all sections

### 🎨 Regeneration UX
- Added visible loading indicators for:
  - Quests
  - Dialogue
  - Items
  - Basic Info
  - Portrait (consolidated and cleaned up messaging)
- Improved loading feedback for "Add Generated Trait" button

### 🐛 Fixes
- Quest regeneration fallback improved to gracefully handle malformed AI responses
- Fixed duplicate portrait editing status messages
- Developer docs section in sidebar now properly highlights active route
